### PR TITLE
Add pre-release week CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   integration-tests:
+    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
+    # Will still run for each push to bump-meilisearch-v*
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Useful for Meili team only.
Add pre-release CIs, related to the pre-release week of MeiliSearch -> https://github.com/meilisearch/integration-guides/blob/master/guides/pre-release-week.md
