### PR TITLE
Add all dart versions support

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -15,8 +15,15 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        version: ['2.7', '2.8']
+        version: [
+          '2.7',
+          '2.8',
+          '2.9',
+          '2.10',
+          '2.12'
+        ]
     name: integration-tests-against-rc (dart ${{ matrix.version }})
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['2.7', '2.8']
+        version: [
+          '2.7',
+          '2.8',
+          '2.9',
+          '2.10',
+          '2.11',
+          '2.12'
+        ]
     name: integration-tests (dart ${{ matrix.version }})
     container:
       image: google/dart:${{ matrix.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        fail-fast: false
         version: [
           '2.7',
           '2.8',

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,6 @@ jobs:
           '2.8',
           '2.9',
           '2.10',
-          '2.11',
           '2.12'
         ]
     name: integration-tests (dart ${{ matrix.version }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         version: [
           '2.7',
           '2.8',

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <p align="center">⚡ The MeiliSearch API client written for Dart</p>
 
-**MeiliSearch Dart** is the MeiliSearch API client for Dart developers. Which you can also use for your Flutter apps as well.
+**MeiliSearch Dart** is the MeiliSearch API client for Dart and Flutter developers.
 
 **MeiliSearch** is an open-source search engine. [Discover what MeiliSearch is!](https://github.com/meilisearch/MeiliSearch)
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,10 @@
 status = [
     'integration-tests (dart 2.7)',
     'integration-tests (dart 2.8)',
+    'integration-tests (dart 2.9)',
+    'integration-tests (dart 2.10)',
+    'integration-tests (dart 2.11)',
+    'integration-tests (dart 2.12)',
     'linter-check'
 ]
 # 1 hour timeout

--- a/bors.toml
+++ b/bors.toml
@@ -3,7 +3,6 @@ status = [
     'integration-tests (dart 2.8)',
     'integration-tests (dart 2.9)',
     'integration-tests (dart 2.10)',
-    'integration-tests (dart 2.11)',
     'integration-tests (dart 2.12)',
     'linter-check'
 ]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: meilisearch
 description: MeiliSearch Dart is the MeiliSearch API client for Dart developers. Which you can also use for your Flutter apps as well.
 version: 0.1.1+1
-homepage: https://github.com/themisir/meilisearch-dart
+homepage: https://github.com/meilisearch/meilisearch-dart
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: meilisearch
-description: MeiliSearch Dart is the MeiliSearch API client for Dart developers. Which you can also use for your Flutter apps as well.
+description: MeiliSearch Dart is the MeiliSearch API client for Dart and Flutter developers.
 version: 0.1.1+1
 homepage: https://github.com/meilisearch/meilisearch-dart
 


### PR DESCRIPTION
There is no Dart 2.11 because it was only in beta -> https://hub.docker.com/r/google/dart/tags?page=1&ordering=last_updated&name=2.11