### PR TITLE
Adding getAllUpdateStatus and getUpdateStatus methods

### DIFF
--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -1,8 +1,11 @@
+import 'package:meilisearch/src/update_status.dart';
+
 import 'index_settings.dart';
 
 import 'pending_update.dart';
 import 'search_result.dart';
 import 'stats.dart' show IndexStats;
+import 'update_status.dart';
 
 abstract class MeiliSearchIndex {
   String get uid;
@@ -150,4 +153,10 @@ abstract class MeiliSearchIndex {
 
   /// Get stats of the index.
   Future<IndexStats> getStats();
+
+  /// Get all update status.
+  Future<List<UpdateStatus>?> getAllUpdateStatus();
+
+  /// Gets an update status based on the update id.
+  Future<UpdateStatus> getUpdateStatus(int updateId);
 }

--- a/lib/src/index_impl.dart
+++ b/lib/src/index_impl.dart
@@ -8,6 +8,7 @@ import 'pending_update.dart';
 import 'pending_update_impl.dart';
 import 'search_result.dart';
 import 'stats.dart' show IndexStats;
+import 'update_status.dart';
 
 class MeiliSearchIndexImpl implements MeiliSearchIndex {
   MeiliSearchIndexImpl(
@@ -401,5 +402,23 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
     final response = await http.getMethod('/indexes/$uid/stats');
 
     return IndexStats.fromMap(response.data);
+  }
+
+  ///
+  /// Update status endpoints
+  ///
+
+  Future<List<UpdateStatus>?> getAllUpdateStatus() async {
+    final response = await http.getMethod('/indexes/$uid/updates');
+
+    return (response.data as List)
+        .map((update) => UpdateStatus.fromMap(update))
+        .toList();
+  }
+
+  Future<UpdateStatus> getUpdateStatus(int updateId) async {
+    final response = await http.getMethod(('/indexes/$uid/updates/$updateId'));
+
+    return UpdateStatus.fromMap(response.data);
   }
 }

--- a/lib/src/pending_update_impl.dart
+++ b/lib/src/pending_update_impl.dart
@@ -17,10 +17,6 @@ class PendingUpdateImpl implements PendingUpdate {
 
   @override
   Future<UpdateStatus> getStatus() async {
-    final response = await index.http.getMethod<Map<String, dynamic>>(
-      '/indexes/${index.uid}/updates/$updateId',
-    );
-
-    return UpdateStatus.fromMap(response.data!);
+    return index.getUpdateStatus(updateId);
   }
 }

--- a/test/indexes_test.dart
+++ b/test/indexes_test.dart
@@ -121,7 +121,7 @@ void main() {
           throwsA(isA<MeiliSearchApiException>()));
     });
 
-    test("Geting index stats", () async {
+    test('Geting index stats', () async {
       final uid = randomUid();
       final index = client.index(uid);
       final response = await index.addDocuments([
@@ -131,6 +131,39 @@ void main() {
       expect(response.status, 'processed');
       final stats = await index.getStats();
       expect(stats.numberOfDocuments, 2);
+    });
+
+    test('Getting all update statuses default', () async {
+      final index = await client.createIndex(randomUid());
+      final response = await index.getAllUpdateStatus();
+      expect(response, []);
+    });
+
+    test('Getting all update statuses', () async {
+      final index = client.index(randomUid());
+      await index.addDocuments([
+        {'book_id': 1234, 'title': 'Pride and Prejudice'}
+      ]);
+      await index.addDocuments([
+        {'book_id': 5678}
+      ]);
+      final update_status = await index.getAllUpdateStatus();
+      expect(update_status!.length, 2);
+    });
+
+    test('Getting update status', () async {
+      final index = client.index(randomUid());
+      final response = await index.addDocuments([
+        {'book_id': 1234, 'title': 'Pride and Prejudice'}
+      ]);
+      final update_status = await index.getUpdateStatus(response.updateId);
+      expect(update_status.updateId, response.updateId);
+    });
+
+    test('Getting non-existant update status', () async {
+      final index = await client.createIndex(randomUid());
+      expect(() async => await index.getUpdateStatus(9999),
+          throwsA(isA<MeiliSearchApiException>()));
     });
   });
 }


### PR DESCRIPTION
Closes #50

I debated the best way to handle the `getStatus` in the `PendingUpdateImpl`. Since it is kind of it's own thing, and is part of the extension in the `Client` I left it and just made it call the `getUpdateStatus` in the `Index`. If you think there is a better way let me know and I can make updates.