### PR TITLE
Update meilisearch code samples for distinct_attribute values

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -111,11 +111,11 @@ update_ranking_rules_1: |-
 reset_ranking_rules_1: |-
   await client.index('movies').resetRankingRules();
 get_distinct_attribute_1: |-
-  await client.index('movies').getDistinctAttribute();
+  await client.index('shoes').getDistinctAttribute();
 update_distinct_attribute_1: |-
-  await client.index('movies').updateDistinctAttribute('movie_id');
+  await client.index('shoes').updateDistinctAttribute('skuid');
 reset_distinct_attribute_1: |-
-  await client.index('movies').resetDistinctAttribute();
+  await client.index('shoes').resetDistinctAttribute();
 get_filterable_attributes_1: |-
   await client.index('movies').getFilterableAttributes();
 update_filterable_attributes_1: |-


### PR DESCRIPTION
This PR addresses issue #106 by updating the `.code-samples.meilisearch.yaml` file in line with https://github.com/meilisearch/documentation/pull/1214

* `distinct_attribute` values were changed from `'movies'` to `'shoes'` and from `'movie_id'` to `'skuid'`