### PR TITLE
Remove getOrCreate from MeiliSearchClient

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -32,10 +32,6 @@ abstract class MeiliSearchClient {
   /// Throws an error if index is already exists.
   Future<MeiliSearchIndex> createIndex(String uid, {String primaryKey});
 
-  /// Find index by matching [uid]. If index is not exists tries to create a
-  /// new index.
-  Future<MeiliSearchIndex> getOrCreateIndex(String uid, {String primaryKey});
-
   /// Delete the index by matching [uid].
   Future<void> deleteIndex(String uid);
 

--- a/lib/src/client_impl.dart
+++ b/lib/src/client_impl.dart
@@ -4,7 +4,6 @@ import 'http_request_impl.dart';
 import 'client.dart';
 import 'index.dart';
 import 'index_impl.dart';
-import 'exception.dart';
 import 'stats.dart' show AllStats;
 
 class MeiliSearchClientImpl implements MeiliSearchClient {
@@ -58,21 +57,6 @@ class MeiliSearchClientImpl implements MeiliSearchClient {
         .cast<Map<String, dynamic>>()
         .map((item) => MeiliSearchIndexImpl.fromMap(this, item))
         .toList();
-  }
-
-  @override
-  Future<MeiliSearchIndex> getOrCreateIndex(
-    String uid, {
-    String? primaryKey,
-  }) async {
-    try {
-      return await getIndex(uid);
-    } on MeiliSearchApiException catch (e) {
-      if (e.code != 'index_not_found') {
-        throw (e);
-      }
-      return await createIndex(uid, primaryKey: primaryKey);
-    }
   }
 
   @override

--- a/test/indexes_test.dart
+++ b/test/indexes_test.dart
@@ -73,29 +73,6 @@ void main() {
       expect(indexes.length, 3);
     });
 
-    test('GetOrCreate index with right UID', () async {
-      final uid = randomUid();
-      await client.getOrCreateIndex(uid);
-      final index = await client.getIndex(uid);
-      expect(index.uid, uid);
-    });
-
-    test('GetOrCreate index with right UID with a primary', () async {
-      final uid = randomUid();
-      await client.getOrCreateIndex(uid, primaryKey: 'myId');
-      final index = await client.getIndex(uid);
-      expect(index.uid, uid);
-      expect(index.primaryKey, 'myId');
-    });
-
-    test('GetOrCreate index on existing index', () async {
-      final uid = randomUid();
-      await client.createIndex(uid);
-      await client.getOrCreateIndex(uid);
-      final index = await client.getIndex(uid);
-      expect(index.uid, uid);
-    });
-
     test('Create index object with UID', () async {
       final uid = randomUid();
       final index = client.index(uid);


### PR DESCRIPTION
As the title says, the idea is to remove `getOrCreate` method accordingly to this https://github.com/meilisearch/integration-guides/issues/157#issuecomment-998826170

Related to MeiliSearch v0.25 https://github.com/meilisearch/integration-guides/issues/157
