### PR TITLE
Add keys support

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,4 +1,5 @@
 import 'package:meilisearch/src/pending_update.dart';
+import 'package:meilisearch/src/key.dart';
 
 import 'http_request.dart';
 import 'index.dart';
@@ -55,7 +56,27 @@ abstract class MeiliSearchClient {
   Future<Map<String, String>> getDumpStatus(String uid);
 
   /// Get the public and private keys.
-  Future<Map<String, String>> getKeys();
+  Future<List<Key>> getKeys();
+
+  /// Get a specific key by key.
+  Future<Key> getKey(String key);
+
+  /// Create a new key.
+  Future<Key> createKey(
+      {DateTime? expiresAt,
+      String? description,
+      required List<String> indexes,
+      required List<String> actions});
+
+  /// Update a key.
+  Future<Key> updateKey(String key,
+      {DateTime? expiresAt,
+      String? description,
+      List<String>? indexes,
+      List<String>? actions});
+
+  /// Delete a key
+  Future<bool> deleteKey(Key key);
 
   /// Get the MeiliSearch version
   Future<Map<String, String>> getVersion();

--- a/lib/src/http_request.dart
+++ b/lib/src/http_request.dart
@@ -20,6 +20,14 @@ abstract class HttpRequest {
     Map<String, dynamic>? queryParameters,
   });
 
+  /// PATCH method
+  Future<Response<T>> patchMethod<T>(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+  });
+
+
   /// POST method
   Future<Response<T>> postMethod<T>(
     String path, {

--- a/lib/src/http_request_impl.dart
+++ b/lib/src/http_request_impl.dart
@@ -7,7 +7,7 @@ class HttpRequestImpl implements HttpRequest {
       : dio = Dio(BaseOptions(
           baseUrl: serverUrl,
           headers: <String, dynamic>{
-            if (apiKey != null) 'X-Meili-API-Key': apiKey,
+            if (apiKey != null) 'Authorization': 'Bearer ${apiKey}',
             'Content-Type': 'application/json',
           },
           responseType: ResponseType.json,
@@ -51,6 +51,25 @@ class HttpRequestImpl implements HttpRequest {
     var response;
     try {
       response = await dio.post<T>(
+        path,
+        data: data,
+        queryParameters: queryParameters,
+      );
+    } on DioError catch (e) {
+      throwException(e);
+    }
+    return await response;
+  }
+
+  @override
+  Future<Response<T>> patchMethod<T>(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+  }) async {
+    var response;
+    try {
+      response = await dio.patch<T>(
         path,
         data: data,
         queryParameters: queryParameters,

--- a/lib/src/key.dart
+++ b/lib/src/key.dart
@@ -1,0 +1,30 @@
+class Key {
+  final String key;
+  final String? description;
+  final List<String> indexes;
+  final List<String> actions;
+  final DateTime? expiresAt;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  Key({
+    this.key: "",
+    this.description,
+    this.actions: const ['*'],
+    this.indexes: const ['*'],
+    this.expiresAt,
+    this.createdAt,
+    this.updatedAt
+  });
+
+
+  factory Key.fromJson(Map<String, dynamic> json) => Key(
+    description: json["description"],
+    key: json["key"],
+    actions: List<String>.from(json["actions"].map((x) => x)),
+    indexes: List<String>.from(json["indexes"].map((x) => x)),
+    expiresAt: DateTime.tryParse(json["expiresAt"] ?? ''),
+    createdAt: DateTime.parse(json["createdAt"]),
+    updatedAt: DateTime.parse(json["updatedAt"]),
+  );
+}

--- a/test/get_keys_test.dart
+++ b/test/get_keys_test.dart
@@ -1,3 +1,6 @@
+import 'package:meilisearch/meilisearch.dart';
+import 'package:meilisearch/src/exception.dart';
+import 'package:meilisearch/src/key.dart';
 import 'package:test/test.dart';
 
 import 'utils/client.dart';
@@ -6,12 +9,129 @@ void main() {
   group('Keys', () {
     setUpClient();
 
-    test('keys are returned from the server', () async {
-      var keys = await client.getKeys();
-      expect(keys.keys, contains('public'));
-      expect(keys.keys, contains('private'));
-      expect(keys['public'], isNotEmpty);
-      expect(keys['private'], isNotEmpty);
+    group('When has master key', () {
+      test('responds with all keys', () async {
+        await client.createKey(indexes: ['movies'], actions: ['*']);
+
+        final allKeys = await client.getKeys();
+
+        expect(allKeys, isA<List<Key>>());
+        expect(allKeys.length, greaterThan(0));
+      });
+
+      test('gets a key from server by key/uid', () async {
+        final _key = await client.createKey(indexes: ['*'], actions: ['*']);
+
+        Key key = await client.getKey(_key.key);
+
+        expect(key.description, equals(_key.description));
+        expect(key.actions, equals(['*']));
+        expect(key.indexes, equals(['*']));
+        expect(key.key, _key.key);
+        expect(key.expiresAt, isNull);
+        expect(key.createdAt, _key.createdAt);
+        expect(key.updatedAt, _key.updatedAt);
+      });
+
+      test('creates a new key', () async {
+        Key key = await client.createKey(
+            description: "awesome-key",
+            actions: ["documents.add"],
+            indexes: ["movies"]);
+
+        expect(key.description, equals("awesome-key"));
+        expect(key.actions, equals(["documents.add"]));
+        expect(key.indexes, equals(["movies"]));
+        expect(key.expiresAt, isNull);
+      });
+
+      test('creates a new key with expiresAt', () async {
+        var dt = DateTime.now().add(const Duration(days: 50)).toUtc();
+
+        Key key = await client.createKey(
+            actions: ["documents.add"], indexes: ["movies"], expiresAt: dt);
+
+        expect(key.description, isNull);
+        // Meilisearch's API doesn't support microseconds/milliseconds
+        // so we must crop them before send and remove it to assert properly.
+        dt = dt.subtract(Duration(
+            microseconds: dt.microsecond, milliseconds: dt.millisecond));
+        expect(key.expiresAt, equals(dt));
+        expect(key.expiresAt!.isAtSameMomentAs(dt), isTrue);
+      });
+
+      test('updates a key partially', () async {
+        final key = await client.createKey(
+            actions: ["*"], indexes: ["*"], expiresAt: DateTime(2114));
+
+        final newKey = await client.updateKey(key.key, indexes: ['movies']);
+
+        expect(newKey.indexes, equals(['movies']));
+        expect(newKey.actions, equals(['*']));
+        expect(newKey.expiresAt, isNotNull);
+        expect(newKey.expiresAt, equals(key.expiresAt));
+        expect(newKey.description, equals(key.description));
+      });
+
+      test('updates key expiresAt', () async {
+        final key = await client.createKey(actions: ["*"], indexes: ["*"]);
+
+        final newKey = await client.updateKey(key.key,
+            expiresAt: DateTime.now().add(Duration(days: 1)));
+
+        expect(key.expiresAt, isNull);
+        expect(newKey.expiresAt, isNotNull);
+      });
+
+      test('deletes a key', () async {
+        final key = await client.createKey(actions: ["*"], indexes: ["*"]);
+
+        expect(await client.deleteKey(key), isTrue);
+      });
+    });
+
+    group('When has a key with search scope only', () {
+      setUp(() async {
+        final key = await client.createKey(indexes: ['*'], actions: ['search']);
+        await client.createIndex('movies').waitFor();
+
+        client = MeiliSearchClient(testServer, key.key);
+      });
+
+      tearDown(() {
+        client = MeiliSearchClient(testServer, 'masterKey');
+      });
+
+      test('throws MeiliSearchApiException in getKeys call', () async {
+        expect(() async => await client.getKeys(),
+            throwsA(isA<MeiliSearchApiException>()));
+      });
+
+      test('throws MeiliSearchApiException in createKey call', () async {
+        expect(
+            () async => await client.createKey(actions: ['*'], indexes: ['*']),
+            throwsA(isA<MeiliSearchApiException>()));
+      });
+
+      test('searches successfully', () async {
+        expect(() async => await client.index('movies').search('name'),
+            returnsNormally);
+      });
+    });
+
+    group('When has a invalid key', () {
+      setUp(() async {
+        client = MeiliSearchClient(testServer, 'this-is-a-invalid-key');
+      });
+
+      tearDown(() {
+        client = MeiliSearchClient(testServer, 'masterKey');
+      });
+
+      test('throws MeiliSearchApiException in getKeys call', () async {
+        expect(() async => await client.getKeys(),
+            throwsA(isA<MeiliSearchApiException>()));
+      });
     });
   });
 }

--- a/test/utils/client.dart
+++ b/test/utils/client.dart
@@ -23,6 +23,14 @@ Future<void> deleteAllIndexes() async {
   }
 }
 
+Future<void> deleteAllKeys() async {
+  var keys = await client.getKeys();
+
+  for (var item in keys) {
+    await client.deleteKey(item);
+  }
+}
+
 Future<void> setUpClient() async {
   setUp(() {
     final String server = testServer;
@@ -35,6 +43,7 @@ Future<void> setUpClient() async {
 
   tearDown(() async {
     await deleteAllIndexes();
+    await deleteAllKeys();
   });
 }
 

--- a/test/utils/client.dart
+++ b/test/utils/client.dart
@@ -12,7 +12,7 @@ late HttpRequest http;
 late MeiliSearchClient client;
 Random random = Random();
 
-String get _testServer {
+String get testServer {
   return Platform.environment['MEILI_SERVER'] ?? 'http://localhost:7700';
 }
 
@@ -25,7 +25,7 @@ Future<void> deleteAllIndexes() async {
 
 Future<void> setUpClient() async {
   setUp(() {
-    final String server = _testServer;
+    final String server = testServer;
 
     print('Using MeiliSearch server on $server for running tests.');
 
@@ -40,7 +40,7 @@ Future<void> setUpClient() async {
 
 Future<void> setUpHttp() async {
   setUp(() {
-    final String server = _testServer;
+    final String server = testServer;
 
     http = HttpRequestImpl(server, 'masterKey');
   });


### PR DESCRIPTION
- Create another teardown method to clean up all keys
- Make `testServer` public to test environment
- Implement CRUD keys-related methods in the client
- Create `Key` class to represent keys resource
- Add support to http `PATCH` method
- Change from `X-Meili-API-Key` to `Authorization` in req headers.

Changes related to the v0.25.0 upgrade.