### PR TITLE
Implement other naming changes after code-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ void main() async {
   ]
 
   // If the index 'movies' does not exist, MeiliSearch creates it when you first add the documents.
-  var update = await index.addDocuments(documents); // => { "updateId": 0 }
+  var task = await index.addDocuments(documents); // => { "uid": 0 }
 }
 ```
 
-With the `updateId`, you can check the status (`enqueued`, `processing`, `processed` or `failed`) of your documents addition using the [update endpoint](https://docs.meilisearch.com/reference/api/updates.html#get-an-update-status).
+With the `uid`, you can check the status (`enqueued`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://docs.meilisearch.com/reference/api/tasks.html#get-task).
 
 #### Basic Search <!-- omit in toc -->
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -85,9 +85,9 @@ abstract class MeiliSearchClient {
   /// Get all index stats.
   Future<AllStats> getStats();
 
-  /// Get all tasks.
+  /// Get a list of tasks from the client.
   Future<List<Task>> getTasks();
 
-  /// Get a task based on the update id.
-  Future<Task> getTask(int updateId);
+  /// Get a task from an index specified by uid with the specified uid.
+  Future<Task> getTask(int uid);
 }

--- a/lib/src/client_impl.dart
+++ b/lib/src/client_impl.dart
@@ -200,8 +200,8 @@ class MeiliSearchClientImpl implements MeiliSearchClient {
   }
 
   @override
-  Future<Task> getTask(int updateId) async {
-    final response = await http.getMethod(('/tasks/$updateId'));
+  Future<Task> getTask(int uid) async {
+    final response = await http.getMethod(('/tasks/$uid'));
 
     return Task.fromMap(response.data);
   }

--- a/lib/src/client_task_impl.dart
+++ b/lib/src/client_task_impl.dart
@@ -4,10 +4,10 @@ import 'package:meilisearch/src/task.dart';
 import 'task_info.dart';
 
 class ClientTaskImpl implements TaskInfo {
-  final int updateId;
+  final int uid;
   final MeiliSearchClientImpl client;
 
-  ClientTaskImpl(this.client, this.updateId);
+  ClientTaskImpl(this.client, this.uid);
 
   factory ClientTaskImpl.fromMap(
     MeiliSearchClientImpl client,
@@ -17,6 +17,6 @@ class ClientTaskImpl implements TaskInfo {
 
   @override
   Future<Task> getStatus() async {
-    return await client.getTask(this.updateId);
+    return await client.getTask(this.uid);
   }
 }

--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -164,5 +164,5 @@ abstract class MeiliSearchIndex {
   Future<List<Task>> getTasks();
 
   /// Get a task based on the update id.
-  Future<Task> getTask(int updateId);
+  Future<Task> getTask(int uid);
 }

--- a/lib/src/index_impl.dart
+++ b/lib/src/index_impl.dart
@@ -432,7 +432,7 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
         .toList();
   }
 
-  Future<Task> getTask(int updateId) async {
-    return await client.getTask(updateId);
+  Future<Task> getTask(int uid) async {
+    return await client.getTask(uid);
   }
 }

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -1,7 +1,7 @@
 class Task {
   Task({
     this.status,
-    this.updateId,
+    this.uid,
     this.type,
     this.duration,
     this.enqueuedAt,
@@ -11,17 +11,17 @@ class Task {
   });
 
   final String? status;
-  final int? updateId;
+  final int? uid;
   final String? type;
   final String? duration;
   final DateTime? enqueuedAt;
   final DateTime? processedAt;
-  final UpdateError? error;
+  final TaskError? error;
   final Map<String, dynamic>? details;
 
   factory Task.fromMap(Map<String, dynamic> map) => Task(
         status: map['status'] as String?,
-        updateId: map['uid'] as int?,
+        uid: map['uid'] as int?,
         duration: map['duration'] as String?,
         enqueuedAt: map['enqueuedAt'] != null
             ? DateTime.tryParse(map['enqueuedAt'] as String)
@@ -31,14 +31,14 @@ class Task {
             : null,
         type: map['type'] as String?,
         error: map['error'] != null
-            ? UpdateError.fromMap(map['error'] as Map<String, dynamic>)
+            ? TaskError.fromMap(map['error'] as Map<String, dynamic>)
             : null,
         details: map['details'],
       );
 }
 
-class UpdateError {
-  UpdateError({
+class TaskError {
+  TaskError({
     this.message,
     this.code,
     this.type,
@@ -50,7 +50,7 @@ class UpdateError {
   final String? type;
   final String? link;
 
-  factory UpdateError.fromMap(Map<String, dynamic> map) => UpdateError(
+  factory TaskError.fromMap(Map<String, dynamic> map) => TaskError(
         message: map['message'] as String?,
         code: map['code'] as String?,
         type: map['type'] as String?,

--- a/lib/src/task_impl.dart
+++ b/lib/src/task_impl.dart
@@ -4,10 +4,10 @@ import 'index_impl.dart';
 import 'task_info.dart';
 
 class TaskImpl implements TaskInfo {
-  final int updateId;
+  final int uid;
   final MeiliSearchIndexImpl index;
 
-  TaskImpl(this.index, this.updateId);
+  TaskImpl(this.index, this.uid);
 
   factory TaskImpl.fromMap(
     MeiliSearchIndexImpl index,
@@ -17,6 +17,6 @@ class TaskImpl implements TaskInfo {
 
   @override
   Future<Task> getStatus() async {
-    return index.getTask(updateId);
+    return index.getTask(uid);
   }
 }

--- a/lib/src/task_info.dart
+++ b/lib/src/task_info.dart
@@ -1,7 +1,7 @@
 import 'task.dart';
 
 abstract class TaskInfo {
-  int get updateId;
+  int get uid;
 
   Future<Task> getStatus();
 }

--- a/test/get_client_stats_test.dart
+++ b/test/get_client_stats_test.dart
@@ -39,10 +39,10 @@ void main() {
       final uid = randomUid();
       final info = await client.createIndex(uid);
 
-      final task = await client.getTask(info.updateId);
+      final task = await client.getTask(info.uid);
 
       expect(task, isA<Task>());
-      expect(task.updateId, equals(info.updateId));
+      expect(task.uid, equals(info.uid));
     });
   });
 }

--- a/test/indexes_test.dart
+++ b/test/indexes_test.dart
@@ -142,16 +142,16 @@ void main() {
         {'book_id': 1234, 'title': 'Pride and Prejudice'}
       ]);
 
-      final task = await index.getTask(response.updateId);
+      final task = await index.getTask(response.uid);
 
-      expect(task.updateId, response.updateId);
+      expect(task.uid, response.uid);
     });
 
     test('gets a task with a failure', () async {
       final index = client.index(randomUid());
       final response =
           await index.updateRankingRules(['wrong_ranking_rules']).waitFor();
-      expect(response.updateId, response.updateId);
+      expect(response.uid, response.uid);
       expect(response.error!.type, 'invalid_request');
     });
 

--- a/test/utils/client.dart
+++ b/test/utils/client.dart
@@ -86,7 +86,7 @@ extension TaskWaiter on TaskInfo {
       await Future.delayed(interval);
     }
 
-    throw Exception('The task ${updateId} timed out.');
+    throw Exception('The task ${uid} timed out.');
   }
 }
 


### PR DESCRIPTION
- Rename updateUid to just uid
- Rename `UpdateError` class to `TaskError`
- Fix statuses in the README.md

All the suggestions from this PR https://github.com/meilisearch/meilisearch-dart/pull/118