### PR TITLE
Feature/Analytics

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -7,6 +7,7 @@ file1='pubspec.yaml'
 file2='example/pubspec.yaml'
 file3='example/pubspec.lock'
 file4='README.md'
+file5='lib/src/version.dart'
 changelog_file='CHANGELOG.md'
 ret=0
 
@@ -14,12 +15,14 @@ file_tag1=$(grep '^version: ' $file1 | cut -d ':' -f 2 | tr -d ' ')
 file_tag2=$(grep 'meilisearch: "' $file2 | cut -d ':' -f 2 | tr -d '"' | tr -d ' ')
 file_tag3=$(grep 'meilisearch' -A 6 $file3 | grep 'version: ' | cut -d ':' -f2 | tr -d '"' | tr -d ' ')
 file_tag4=$(grep 'meilisearch: ' $file4 | cut -d '^' -f2)
-if [ "$current_tag" != "$file_tag1" ] || [ "$current_tag" != "$file_tag2" ] || [ "$current_tag" != "$file_tag3" ] || [ "$current_tag" != "$file_tag4" ]; then
+file_tag5=$(grep -o "[0-9\.]" $file5 | tr -d '[:space:]')
+if [ "$current_tag" != "$file_tag1" ] || [ "$current_tag" != "$file_tag2" ] || [ "$current_tag" != "$file_tag3" ] || [ "$current_tag" != "$file_tag4" ] || [ "$current_tag" != "$file_tag5" ]; then
   echo "Error: the current tag does not match the version in package file(s)."
   echo "$file1: found $file_tag1 - expected $current_tag"
   echo "$file2: found $file_tag2 - expected $current_tag"
   echo "$file3: found $file_tag3 - expected $current_tag"
-  echo "$file4: found $file_tag4 - expected $round_current_tag"
+  echo "$file4: found $file_tag4 - expected $current_tag"
+  echo "$file5: found $file_tag5 - expected $current_tag"
   ret=1
 fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,12 @@ _[Read more about this](https://github.com/meilisearch/integration-guides/blob/m
 
 Make a PR modifying the version in:
 
+- the file [`lib/src/version.dart:2`](./lib/src/version.dart).
+
+```dart
+static const String current = 'X.X.X';
+```
+
 - the file [`pubspec.yaml`](./pubspec.yaml).
 
 ```yaml

--- a/lib/src/http_request.dart
+++ b/lib/src/http_request.dart
@@ -14,6 +14,9 @@ abstract class HttpRequest {
   /// Timeout in milliseconds for opening a url.
   int? get connectTimeout;
 
+  /// Retrieve all headers used when Http calls are made.
+  Map<String, dynamic> headers();
+
   /// GET method
   Future<Response<T>> getMethod<T>(
     String path, {

--- a/lib/src/http_request_impl.dart
+++ b/lib/src/http_request_impl.dart
@@ -10,6 +10,7 @@ class HttpRequestImpl implements HttpRequest {
           headers: <String, dynamic>{
             if (apiKey != null) 'Authorization': 'Bearer ${apiKey}',
             'Content-Type': 'application/json',
+            'User-Agent': Version.qualifiedVersion,
           },
           responseType: ResponseType.json,
           connectTimeout: connectTimeout ?? 0,

--- a/lib/src/http_request_impl.dart
+++ b/lib/src/http_request_impl.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:meilisearch/src/version.dart';
 import 'http_request.dart';
 import 'exception.dart';
 
@@ -24,6 +25,11 @@ class HttpRequestImpl implements HttpRequest {
   final int? connectTimeout;
 
   final Dio dio;
+
+  @override
+  Map<String, dynamic> headers() {
+    return this.dio.options.headers;
+  }
 
   @override
   Future<Response<T>> getMethod<T>(

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,7 @@
+class Version {
+  static const String current = '0.5.0';
+
+  static String get qualifiedVersion {
+    return "MeiliSearch Dart (v${current})";
+  }
+}

--- a/test/analytics_test.dart
+++ b/test/analytics_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:meilisearch/src/version.dart';
+import 'package:test/test.dart';
+
+import 'utils/client.dart';
+
+void main() {
+  final RegExp semVer = new RegExp(
+      r"version\:.(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?");
+
+  group('Version', () {
+    test('matches with the current package version in pubspec.yaml', () {
+      final path = '${Directory.current.path}/pubspec.yaml';
+      String data = new File(path).readAsStringSync();
+      String? version = semVer.stringMatch(data)?.replaceFirst('version: ', '');
+
+      expect(version, isNotNull);
+      expect(Version.current, isNotNull);
+      expect(Version.current, equals(version));
+    });
+  });
+
+  group('Analytics', () {
+    setUpClient();
+
+    test('sends the User-Agent header in every call', () {
+      final headers = client.http.headers();
+
+      expect(headers.keys, contains('User-Agent'));
+      expect(headers['User-Agent'], isNotNull);
+    });
+
+    test('has current version data from Version class', () {
+      final headers = client.http.headers();
+
+      expect(headers['User-Agent'], equals(Version.qualifiedVersion));
+    });
+  });
+}


### PR DESCRIPTION
- Expose headers method 
- Create a `Version` class to easily access package version data.
- Add `Version.qualifiedVersion` to headers

After the implementation the MeiliSearch server is outputting the expected 💯 
`[2022-01-19T18:33:47Z INFO  actix_web::middleware::logger] 172.17.0.1:57704 "GET /keys HTTP/1.1" 200 14 "-" "MeiliSearch Dart (v0.5.0)" 0.000118`


_DISCLAIMER:_ I've tried other ways to collect these data eg. 
- Reading from pubspec.yaml:
  - This is not supported by dart native and flutter in the same way.  
- Generating the version class dynamically:
  - Due to the time constraint I was not able to do this, actually, I don’t know for sure if this is going to work exactly the same way as it is now.   


Add dart support as requested here https://github.com/meilisearch/integration-guides/issues/150