### PR TITLE
Add new search parameters highlightPreTag, highlightPostTag and cropMarker

### DIFF
--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -32,6 +32,9 @@ abstract class MeiliSearchIndex {
     int? cropLength,
     List<String>? attributesToHighlight,
     bool? matches,
+    String? cropMarker,
+    String? highlightPreTag,
+    String? highlightPostTag,
   });
 
   /// Return the document in the index by given [id].

--- a/lib/src/index_impl.dart
+++ b/lib/src/index_impl.dart
@@ -115,6 +115,9 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
     int? cropLength,
     List<String>? attributesToHighlight,
     bool? matches,
+    String? cropMarker,
+    String? highlightPreTag,
+    String? highlightPostTag,
   }) async {
     final data = <String, dynamic>{
       'q': query,
@@ -128,6 +131,9 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
       'cropLength': cropLength,
       'attributesToHighlight': attributesToHighlight,
       'matches': matches,
+      'cropMarker': cropMarker,
+      'highlightPreTag': highlightPreTag,
+      'highlightPostTag': highlightPostTag,
     };
     data.removeWhere((k, v) => v == null);
     final response = await http.postMethod('/indexes/$uid/search', data: data);

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -52,6 +52,33 @@ void main() {
         expect(result.hits![0]['_formatted']['title'], equals('Alice In…'));
       });
 
+      test('searches with default cropping parameters', () async {
+        var index = await createBooksIndex();
+        var result = await index.search('prince',
+            attributesToCrop: ['*'], cropLength: 2);
+
+        expect(result.hits![0]['_formatted']['title'], equals('…Petit Prince'));
+      });
+
+      test('searches with custom cropMarker', () async {
+        var index = await createBooksIndex();
+        var result = await index.search('prince',
+            attributesToCrop: ['*'], cropLength: 1, cropMarker: '[…] ');
+
+        expect(result.hits![0]['_formatted']['title'], equals('[…] Prince'));
+      });
+
+      test('searches with custom highlight tags', () async {
+        var index = await createBooksIndex();
+        var result = await index.search('blood',
+            attributesToHighlight: ['*'],
+            highlightPreTag: '<mark>',
+            highlightPostTag: '</mark>');
+
+        expect(result.hits![0]['_formatted']['title'],
+            equals('Harry Potter and the Half-<mark>Blood</mark> Prince'));
+      });
+
       test('filter parameter', () async {
         var index = await createBooksIndex();
         var response = await index


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2214 new search parameters are introduced:

- `highlightPreTag`
- `highlightPostTag`
- `cropMarker`

This PR adds tests to ensure the new parameters are working.