### PR TITLE
Update version for the next release (v0.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.5.3
+This version makes this package compatible with Meilisearch v0.27.0 and newer
+## Changes
+- Ensure nested field support (#157) @brunoocasali
+- Add `highlightPreTag`, `highlightPostTag`, `cropMarker`, parameters in the search request (#156) @brunoocasali
+- Fix syntax issue in the README (#162) @mafreud
+
 # 0.5.2
 - * Added new method `generateTenantToken()` as a result of the addition of the multi-tenant functionality.
 This method creates a JWT tenant token that will allow the user to have multi-tenant indexes and thus restrict access to documents based on the end-user making the search request. (#139) @brunoocasali

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can install the **meilisearch** package by adding a few lines into `pubspec.
 
 ```yaml
 dependencies:
-  meilisearch: ^0.5.2
+  meilisearch: ^0.5.3
 ```
 
 Then open your terminal and update dart packages.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.2"
+    version: "0.5.3"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  meilisearch: "0.5.2"
+  meilisearch: "0.5.3"
 
 dependency_overrides:
   meilisearch:

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,5 +1,5 @@
 class Version {
-  static const String current = '0.5.2';
+  static const String current = '0.5.3';
 
   static String get qualifiedVersion {
     return "Meilisearch Dart (v${current})";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: meilisearch
 description: Meilisearch Dart is the Meilisearch API client for Dart and Flutter developers.
-version: 0.5.2
+version: 0.5.3
 homepage: https://github.com/meilisearch/meilisearch-dart
 
 environment:


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.27.0 :tada:
Check out the changelog of [Meilisearch v0.27.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.27.0) for more information on the changes.

## 🚀 Enhancements

- Ensure nested field support (#157) @brunoocasali
- Add `highlightPreTag`, `highlightPostTag`, `cropMarker`, parameters in the search request (#156) @brunoocasali

## 💅 Misc

- Fix syntax issue in the README (#162) @mafreud

Thanks again to @mafreud and @brunoocasali! 🎉
