### PR TITLE
Tasks refactor

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,4 +1,6 @@
 import 'package:meilisearch/src/key.dart';
+import 'package:meilisearch/src/query_parameters/tasks_query.dart';
+import 'package:meilisearch/src/result_task.dart';
 import 'package:meilisearch/src/task.dart';
 import 'package:meilisearch/src/task_info.dart';
 
@@ -90,7 +92,7 @@ abstract class MeiliSearchClient {
   Future<AllStats> getStats();
 
   /// Get a list of tasks from the client.
-  Future<List<Task>> getTasks();
+  Future<ResultTask> getTasks({TasksQuery? params});
 
   /// Get a task from an index specified by uid with the specified uid.
   Future<Task> getTask(int uid);

--- a/lib/src/client_impl.dart
+++ b/lib/src/client_impl.dart
@@ -1,5 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:meilisearch/src/client_task_impl.dart';
+import 'package:meilisearch/src/query_parameters/tasks_query.dart';
+import 'package:meilisearch/src/result_task.dart';
 import 'package:meilisearch/src/task.dart';
 import 'package:meilisearch/src/task_info.dart';
 import 'package:meilisearch/src/tenant_token.dart';
@@ -202,12 +204,11 @@ class MeiliSearchClientImpl implements MeiliSearchClient {
   ///
 
   @override
-  Future<List<Task>> getTasks() async {
-    final response = await http.getMethod('/tasks');
+  Future<ResultTask> getTasks({TasksQuery? params}) async {
+    final response =
+        await http.getMethod('/tasks', queryParameters: params?.toQuery());
 
-    return (response.data['results'] as List)
-        .map((update) => Task.fromMap(update))
-        .toList();
+    return ResultTask.fromMap(response.data);
   }
 
   @override

--- a/lib/src/client_task_impl.dart
+++ b/lib/src/client_task_impl.dart
@@ -13,7 +13,7 @@ class ClientTaskImpl implements TaskInfo {
     MeiliSearchClientImpl client,
     Map<String, dynamic> map,
   ) =>
-      ClientTaskImpl(client, map['taskUid'] as int);
+      ClientTaskImpl(client, (map['uid'] ?? map['taskUid']) as int);
 
   @override
   Future<Task> getStatus() async {

--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -1,3 +1,6 @@
+import 'package:meilisearch/src/query_parameters/tasks_query.dart';
+import 'package:meilisearch/src/result_task.dart';
+
 import 'index_settings.dart';
 
 import 'task_info.dart';
@@ -164,7 +167,7 @@ abstract class MeiliSearchIndex {
   Future<IndexStats> getStats();
 
   /// Get all tasks from the index.
-  Future<List<Task>> getTasks();
+  Future<ResultTask> getTasks({TasksQuery? params});
 
   /// Get a task from an index specified by uid.
   Future<Task> getTask(int uid);

--- a/lib/src/index_impl.dart
+++ b/lib/src/index_impl.dart
@@ -1,4 +1,6 @@
 import 'package:dio/dio.dart';
+import 'package:meilisearch/src/query_parameters/tasks_query.dart';
+import 'package:meilisearch/src/result_task.dart';
 
 import 'client.dart';
 import 'index.dart';
@@ -430,12 +432,15 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
   /// Tasks endpoints
   ///
 
-  Future<List<Task>> getTasks() async {
-    final response = await http.getMethod('/indexes/$uid/tasks');
+  @override
+  Future<ResultTask> getTasks({TasksQuery? params}) async {
+    if (params == null) {
+      params = TasksQuery(indexUid: [this.uid]);
+    } else {
+      params.indexUid.add(this.uid);
+    }
 
-    return (response.data['results'] as List)
-        .map((update) => Task.fromMap(update))
-        .toList();
+    return await client.getTasks(params: params);
   }
 
   Future<Task> getTask(int uid) async {

--- a/lib/src/query_parameters/tasks_query.dart
+++ b/lib/src/query_parameters/tasks_query.dart
@@ -1,0 +1,29 @@
+class TasksQuery {
+  final int? from;
+  final int? next;
+  final int? limit;
+  List<String> status;
+  List<String> type;
+  List<String> indexUid;
+
+  TasksQuery(
+      {this.limit,
+      this.from,
+      this.next,
+      this.indexUid: const [],
+      this.status: const [],
+      this.type: const []});
+
+  Map<String, dynamic> toQuery() {
+    return <String, dynamic>{
+      'from': this.from,
+      'next': this.next,
+      'limit': this.limit,
+      'indexUid': this.indexUid,
+      'status': this.status,
+      'type': this.type,
+    }
+      ..removeWhere((key, val) => val == null || (val is List && val.isEmpty))
+      ..updateAll((key, val) => val is List ? val.join(',') : val);
+  }
+}

--- a/lib/src/result_task.dart
+++ b/lib/src/result_task.dart
@@ -1,0 +1,22 @@
+import 'package:meilisearch/src/task.dart';
+
+class ResultTask<T> {
+  final List<Task> results;
+  final int? next;
+  final int? limit;
+  final int? from;
+
+  ResultTask(
+      {this.results: const [],
+      this.limit: null,
+      this.from: null,
+      this.next: null});
+
+  factory ResultTask.fromMap(Map<String, dynamic> map) => ResultTask(
+        results:
+            (map['results'] as List).map((item) => Task.fromMap(item)).toList(),
+        next: map['next'] as int?,
+        from: map['from'] as int?,
+        limit: map['limit'] as int?,
+      );
+}

--- a/lib/src/task_impl.dart
+++ b/lib/src/task_impl.dart
@@ -13,7 +13,7 @@ class TaskImpl implements TaskInfo {
     MeiliSearchIndexImpl index,
     Map<String, dynamic> map,
   ) =>
-      TaskImpl(index, map['taskUid'] as int);
+      TaskImpl(index, (map['uid'] ?? map['taskUid']) as int);
 
   @override
   Future<Task> getStatus() async {

--- a/test/get_client_stats_test.dart
+++ b/test/get_client_stats_test.dart
@@ -32,7 +32,8 @@ void main() {
 
       final tasks = await client.getTasks();
 
-      expect(tasks.length, greaterThan(0));
+      expect(tasks.results.length, greaterThan(0));
+      expect(tasks.results.first, isA<Task>());
     });
 
     test('gets a task by taskId', () async {

--- a/test/indexes_test.dart
+++ b/test/indexes_test.dart
@@ -146,7 +146,7 @@ void main() {
 
       final tasks = await index.getTasks();
 
-      expect(tasks.length, 3);
+      expect(tasks.results.length, equals(3));
     });
 
     test('gets a task from a index by taskId', () async {
@@ -155,9 +155,9 @@ void main() {
         {'book_id': 1234, 'title': 'Pride and Prejudice'}
       ]);
 
-      final task = await index.getTask(response.uid);
+      final task = await index.getTask(response.taskUid);
 
-      expect(task.uid, response.uid);
+      expect(task.uid, response.taskUid);
     });
 
     test('gets a task with a failure', () async {


### PR DESCRIPTION
- Add `TasksQuery` object, which adds the ability to paginate the results using a keyset pagination.
  - `limit`, `next`, `from` attributes handle the pagination.
  - `indexUid` is used to filter tasks by index.
  - `status` is used to filter tasks by status (`succeeded`, `failed` and so on...)
  - `type` is used to filter tasks by type (`dumpCreation`, `documentDeletion`, `indexCreation` and so on...)
- `MeiliSearchIndex`.`getTasks();` now returns `ResultTask`.