### PR TITLE
Add a way to pass fields to getDocument

### DIFF
--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -42,7 +42,7 @@ abstract class MeiliSearchIndex {
   });
 
   /// Return the document in the index by given [id].
-  Future<Map<String, dynamic>?> getDocument(dynamic id);
+  Future<Map<String, dynamic>?> getDocument(dynamic id, { List<String> fields });
 
   /// Return a list of all existing documents in the index.
   Future<Result> getDocuments({DocumentsQuery? params});

--- a/lib/src/index_impl.dart
+++ b/lib/src/index_impl.dart
@@ -199,9 +199,11 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
   }
 
   @override
-  Future<Map<String, dynamic>?> getDocument(id) async {
+  Future<Map<String, dynamic>?> getDocument(id, { List<String> fields: const [] }) async {
+    final params = DocumentsQuery(fields: fields);
     final response = await http.getMethod<Map<String, dynamic>>(
       '/indexes/$uid/documents/$id',
+      queryParameters: params.toQuery()
     );
 
     return response.data;

--- a/test/documents_test.dart
+++ b/test/documents_test.dart
@@ -78,5 +78,13 @@ void main() {
       expect(docs.results[0]['book_id'], isNotNull);
       expect(docs.results[0]['title'], isNull);
     });
+
+    test('Get document with fields', () async {
+      final index = await createBooksIndex();
+      final doc = await index.getDocument(1, fields: ['book_id']);
+
+      expect(doc?['book_id'], isNotNull);
+      expect(doc?['title'], isNull);
+    });
   });
 }


### PR DESCRIPTION
Add support to `fields` in `getDocument` call. I did not use the `DocumentsQuey` here because none of the others limit, offset would work here, so to prevent misunderstandings, I just opted to use plain `fields`.