### PR TITLE
Add support to matchingStrategy search parameter

### DIFF
--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -5,6 +5,7 @@ import 'package:meilisearch/src/tasks_results.dart';
 
 import 'index_settings.dart';
 
+import 'matching_strategy_enum.dart';
 import 'search_result.dart';
 import 'stats.dart' show IndexStats;
 import 'task.dart';
@@ -39,6 +40,7 @@ abstract class MeiliSearchIndex {
     String? cropMarker,
     String? highlightPreTag,
     String? highlightPostTag,
+    MatchingStrategy? matchingStrategy,
   });
 
   /// Return the document in the index by given [id].

--- a/lib/src/index_impl.dart
+++ b/lib/src/index_impl.dart
@@ -8,6 +8,7 @@ import 'client.dart';
 import 'index.dart';
 import 'http_request.dart';
 import 'index_settings.dart';
+import 'matching_strategy_enum.dart';
 import 'search_result.dart';
 import 'stats.dart' show IndexStats;
 import 'task.dart';
@@ -120,6 +121,7 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
     String? cropMarker,
     String? highlightPreTag,
     String? highlightPostTag,
+    MatchingStrategy? matchingStrategy,
   }) async {
     final data = <String, dynamic>{
       'q': query,
@@ -136,6 +138,7 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
       'cropMarker': cropMarker,
       'highlightPreTag': highlightPreTag,
       'highlightPostTag': highlightPostTag,
+      'matchingStrategy': matchingStrategy?.name,
     };
     data.removeWhere((k, v) => v == null);
     final response = await http.postMethod('/indexes/$uid/search', data: data);

--- a/lib/src/matching_strategy_enum.dart
+++ b/lib/src/matching_strategy_enum.dart
@@ -1,0 +1,17 @@
+enum MatchingStrategy {
+  all,
+  last,
+}
+
+extension MatchingStrategyExtension on MatchingStrategy {
+  String get name {
+    switch (this) {
+      case MatchingStrategy.all:
+        return 'all';
+      case MatchingStrategy.last:
+        return 'last';
+      default:
+        return 'last';
+    }
+  }
+}

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -1,5 +1,6 @@
 import 'package:meilisearch/meilisearch.dart';
 import 'package:test/test.dart';
+import 'package:meilisearch/src/matching_strategy_enum.dart';
 
 import 'utils/books.dart';
 import 'utils/client.dart';
@@ -77,6 +78,38 @@ void main() {
 
         expect(result.hits![0]['_formatted']['title'],
             equals('Harry Potter and the Half-<mark>Blood</mark> Prince'));
+      });
+
+      test('searches with matching strategy last', () async {
+        var index = await createBooksIndex();
+        var result = await index.search(
+          'the to',
+          matchingStrategy: MatchingStrategy.last,
+        );
+
+        expect(result.hits!.last['title'],
+            equals('Harry Potter and the Half-Blood Prince'));
+      });
+
+      test('searches with matching strategy all', () async {
+        var index = await createBooksIndex();
+        var result = await index.search(
+          'the to',
+          matchingStrategy: MatchingStrategy.all,
+        );
+
+        expect(result.hits!.last['title'],
+            equals('The Hitchhiker\'s Guide to the Galaxy'));
+      });
+
+      test('searches with matching strategy as null if not set', () async {
+        var index = await createBooksIndex();
+        var result = await index.search(
+          'the to',
+        );
+
+        expect(result.hits!.last['title'],
+            equals('Harry Potter and the Half-Blood Prince'));
       });
 
       test('filter parameter', () async {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #207

## What does this PR do?
- Add support to `matchingStrategy` search parameter.
- Use `enum` to validate the only possible values: `'all'` or `'last'`.

_Note: this is the very first time I code in Dart 🎉 ._

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
