### PR TITLE
Fix field name plurals: statuses, types, indexUids from TaskQuery class

### DIFF
--- a/lib/src/index_impl.dart
+++ b/lib/src/index_impl.dart
@@ -429,9 +429,9 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
   @override
   Future<TasksResults> getTasks({TasksQuery? params}) async {
     if (params == null) {
-      params = TasksQuery(indexUid: [this.uid]);
+      params = TasksQuery(indexUids: [this.uid]);
     } else {
-      params.indexUid.add(this.uid);
+      params.indexUids.add(this.uid);
     }
 
     return await client.getTasks(params: params);

--- a/lib/src/query_parameters/tasks_query.dart
+++ b/lib/src/query_parameters/tasks_query.dart
@@ -2,26 +2,26 @@ class TasksQuery {
   final int? from;
   final int? next;
   final int? limit;
-  List<String> status;
-  List<String> type;
-  List<String> indexUid;
+  List<String> statuses;
+  List<String> types;
+  List<String> indexUids;
 
   TasksQuery(
       {this.limit,
       this.from,
       this.next,
-      this.indexUid: const [],
-      this.status: const [],
-      this.type: const []});
+      this.indexUids: const [],
+      this.statuses: const [],
+      this.types: const []});
 
   Map<String, dynamic> toQuery() {
     return <String, dynamic>{
       'from': this.from,
       'next': this.next,
       'limit': this.limit,
-      'indexUid': this.indexUid,
-      'status': this.status,
-      'type': this.type,
+      'indexUids': this.indexUids,
+      'statuses': this.statuses,
+      'types': this.types,
     }
       ..removeWhere((key, val) => val == null || (val is List && val.isEmpty))
       ..updateAll((key, val) => val is List ? val.join(',') : val);


### PR DESCRIPTION
Change `TaskQuery` field names:

- From `indexUid` to `indexUids`
- From `status` to `statuses`
- From `type` to `types`.