### PR TITLE
Add pagination

### DIFF
--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -1,12 +1,12 @@
 import 'package:meilisearch/src/query_parameters/documents_query.dart';
 import 'package:meilisearch/src/query_parameters/tasks_query.dart';
 import 'package:meilisearch/src/result.dart';
+import 'package:meilisearch/src/searchable.dart';
 import 'package:meilisearch/src/tasks_results.dart';
 
 import 'index_settings.dart';
 
 import 'matching_strategy_enum.dart';
-import 'search_result.dart';
 import 'stats.dart' show IndexStats;
 import 'task.dart';
 
@@ -25,10 +25,12 @@ abstract class MeiliSearchIndex {
   Future<Task> delete();
 
   /// Search for documents matching a specific query in the index.
-  Future<SearchResult> search(
+  Future<Searcheable> search(
     String? query, {
     int? offset,
     int? limit,
+    int? page,
+    int? hitsPerPage,
     dynamic filter,
     List<String>? sort,
     List<String>? facets,

--- a/lib/src/index_impl.dart
+++ b/lib/src/index_impl.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:meilisearch/src/query_parameters/documents_query.dart';
 import 'package:meilisearch/src/query_parameters/tasks_query.dart';
 import 'package:meilisearch/src/result.dart';
+import 'package:meilisearch/src/searchable.dart';
 import 'package:meilisearch/src/tasks_results.dart';
 
 import 'client.dart';
@@ -9,7 +10,6 @@ import 'index.dart';
 import 'http_request.dart';
 import 'index_settings.dart';
 import 'matching_strategy_enum.dart';
-import 'search_result.dart';
 import 'stats.dart' show IndexStats;
 import 'task.dart';
 
@@ -106,10 +106,12 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
   //
 
   @override
-  Future<SearchResult> search(
+  Future<Searcheable> search(
     String? query, {
     int? offset,
     int? limit,
+    int? page,
+    int? hitsPerPage,
     dynamic filter,
     List<String>? sort,
     List<String>? facets,
@@ -127,6 +129,8 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
       'q': query,
       'offset': offset,
       'limit': limit,
+      'page': page,
+      'hitsPerPage': hitsPerPage,
       'filter': filter,
       'sort': sort,
       'facets': facets,
@@ -143,7 +147,7 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
     data.removeWhere((k, v) => v == null);
     final response = await http.postMethod('/indexes/$uid/search', data: data);
 
-    return SearchResult.fromMap(response.data);
+    return Searcheable.createSearchResult(response.data);
   }
 
   //

--- a/lib/src/paginated_search_result.dart
+++ b/lib/src/paginated_search_result.dart
@@ -1,0 +1,39 @@
+import 'package:meilisearch/src/searchable.dart';
+
+class PaginatedSearchResult extends Searcheable {
+  PaginatedSearchResult({
+    this.hitsPerPage,
+    this.page,
+    this.totalHits,
+    this.totalPages,
+  });
+
+  /// Number of documents skipped
+  final int? hitsPerPage;
+
+  /// Number of documents to take
+  final int? page;
+
+  /// Total number of matches
+  final int? totalHits;
+
+  /// Total number of pages
+  final int? totalPages;
+
+  factory PaginatedSearchResult.fromMap(Map<String, dynamic> map) {
+    var result = PaginatedSearchResult(
+      page: map['page'] as int?,
+      hitsPerPage: map['hitsPerPage'] as int?,
+      totalHits: map['totalHits'] as int?,
+      totalPages: map['totalPages'] as int?,
+    );
+
+    result.hits = (map['hits'] as List?)?.cast<Map<String, dynamic>>();
+    result.query = map['query'] as String?;
+    result.processingTimeMs = map['processingTimeMs'] as int?;
+    result.facetDistribution = map['facetDistribution'] as dynamic;
+    result.matchesPosition = map['_matchesPosition'] as dynamic;
+
+    return result;
+  }
+}

--- a/lib/src/search_result.dart
+++ b/lib/src/search_result.dart
@@ -1,16 +1,11 @@
-class SearchResult {
+import 'package:meilisearch/src/searchable.dart';
+
+class SearchResult extends Searcheable {
   SearchResult({
-    this.hits,
     this.offset,
     this.limit,
-    this.processingTimeMs,
-    this.query,
     this.estimatedTotalHits,
-    this.facetDistribution,
   });
-
-  /// Results of the query
-  final List<Map<String, dynamic>>? hits;
 
   /// Number of documents skipped
   final int? offset;
@@ -18,27 +13,22 @@ class SearchResult {
   /// Number of documents to take
   final int? limit;
 
-  /// Processing time of the query
-  final int? processingTimeMs;
-
-  /// Total number of matches
+  /// Estimated number of matches
   final int? estimatedTotalHits;
 
-  /// Distribution of the given facets
-  final dynamic facetDistribution;
-
-  /// Query originating the response
-  final String? query;
-
   factory SearchResult.fromMap(Map<String, dynamic> map) {
-    return SearchResult(
-      hits: (map['hits'] as List?)?.cast<Map<String, dynamic>>(),
-      query: map['query'] as String?,
+    var result = SearchResult(
       limit: map['limit'] as int?,
       offset: map['offset'] as int?,
-      processingTimeMs: map['processingTimeMs'] as int?,
       estimatedTotalHits: map['estimatedTotalHits'] as int?,
-      facetDistribution: map['facetDistribution'] as dynamic,
     );
+
+    result.hits = (map['hits'] as List?)?.cast<Map<String, dynamic>>();
+    result.query = map['query'] as String?;
+    result.processingTimeMs = map['processingTimeMs'] as int?;
+    result.facetDistribution = map['facetDistribution'] as dynamic;
+    result.matchesPosition = map['_matchesPosition'] as dynamic;
+
+    return result;
   }
 }

--- a/lib/src/searchable.dart
+++ b/lib/src/searchable.dart
@@ -1,0 +1,27 @@
+import 'package:meilisearch/meilisearch.dart';
+import 'package:meilisearch/src/paginated_search_result.dart';
+
+abstract class Searcheable {
+  /// Query originating the response
+  String? query;
+
+  /// Results of the query
+  List<Map<String, dynamic>>? hits;
+
+  /// Distribution of the given facets
+  dynamic facetDistribution;
+
+  /// Contains the location of each occurrence of queried terms across all fields
+  dynamic matchesPosition;
+
+  /// Processing time of the query
+  int? processingTimeMs;
+
+  static Searcheable createSearchResult(Map<String, dynamic> map) {
+    if (map['totalHits'] != null) {
+      return PaginatedSearchResult.fromMap(map);
+    } else {
+      return SearchResult.fromMap(map);
+    }
+  }
+}

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -1,4 +1,5 @@
 import 'package:meilisearch/meilisearch.dart';
+import 'package:meilisearch/src/paginated_search_result.dart';
 import 'package:test/test.dart';
 import 'package:meilisearch/src/matching_strategy_enum.dart';
 
@@ -262,6 +263,31 @@ void main() {
           "reviewNb": 1000,
         },
       });
+    });
+  });
+
+  group('with finite-pagination query params', () {
+    test('with basic query', () async {
+      var index = await createBooksIndex();
+      var result = await index.search('pri', page: 1) as PaginatedSearchResult;
+
+      expect(result.totalPages, 1);
+    });
+
+    test('accesses fields from Searchable', () async {
+      var index = await createBooksIndex();
+      var result = await index.search('pri', page: 1) as PaginatedSearchResult;
+
+      expect(result.hits!.length, greaterThanOrEqualTo(1));
+      expect(result.totalPages, 1);
+    });
+
+    test('with mixed pagination query params', () async {
+      var index = await createBooksIndex();
+      var result = await index.search('pri', page: 1, limit: 10)
+          as PaginatedSearchResult;
+
+      expect(result.totalPages, 1);
     });
   });
 }


### PR DESCRIPTION
- Add `PaginatedSearchResult` class.
- Change response type from search method `Future<SearchResult> search(...)` to `Future<Searcheable> search(...)`. 
To access specific fields like `offset`, `limit`, `page`, or `hitsPerPage` it is required to cast the result to the expected type: `await index.search('pri', page: 1) as PaginatedSearchResult;`