### PR TITLE
Add delete tasks method

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,5 +1,6 @@
 import 'package:meilisearch/src/key.dart';
 import 'package:meilisearch/src/query_parameters/cancel_tasks_query.dart';
+import 'package:meilisearch/src/query_parameters/delete_tasks_query.dart';
 import 'package:meilisearch/src/query_parameters/indexes_query.dart';
 import 'package:meilisearch/src/query_parameters/keys_query.dart';
 import 'package:meilisearch/src/query_parameters/tasks_query.dart';
@@ -99,4 +100,7 @@ abstract class MeiliSearchClient {
 
   /// Cancel tasks based on the input query params
   Future<Task> cancelTasks({CancelTasksQuery? params});
+
+  /// Delete old processed tasks based on the input query params
+  Future<Task> deleteTasks({DeleteTasksQuery? params});
 }

--- a/lib/src/client_impl.dart
+++ b/lib/src/client_impl.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:meilisearch/src/query_parameters/cancel_tasks_query.dart';
+import 'package:meilisearch/src/query_parameters/delete_tasks_query.dart';
 import 'package:meilisearch/src/query_parameters/indexes_query.dart';
 import 'package:meilisearch/src/query_parameters/keys_query.dart';
 import 'package:meilisearch/src/query_parameters/tasks_query.dart';
@@ -213,6 +214,14 @@ class MeiliSearchClientImpl implements MeiliSearchClient {
   Future<Task> cancelTasks({CancelTasksQuery? params}) async {
     final response = await http.postMethod('/tasks/cancel',
         queryParameters: params?.toQuery());
+
+    return Task.fromMap(response.data);
+  }
+
+  @override
+  Future<Task> deleteTasks({DeleteTasksQuery? params}) async {
+    final response =
+        await http.deleteMethod('/tasks', queryParameters: params?.toQuery());
 
     return Task.fromMap(response.data);
   }

--- a/lib/src/http_request.dart
+++ b/lib/src/http_request.dart
@@ -45,5 +45,9 @@ abstract class HttpRequest {
   });
 
   /// DELETE method
-  Future<Response<T>> deleteMethod<T>(String path, {dynamic data});
+  Future<Response<T>> deleteMethod<T>(
+    String path, {
+    dynamic data: null,
+    Map<String, dynamic>? queryParameters,
+  });
 }

--- a/lib/src/http_request_impl.dart
+++ b/lib/src/http_request_impl.dart
@@ -99,11 +99,16 @@ class HttpRequestImpl implements HttpRequest {
   }
 
   @override
-  Future<Response<T>> deleteMethod<T>(String path, {dynamic data}) async {
+  Future<Response<T>> deleteMethod<T>(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+  }) async {
     try {
       return await dio.delete<T>(
         path,
         data: data,
+        queryParameters: queryParameters,
       );
     } on DioError catch (e) {
       return throwException(e);

--- a/lib/src/query_parameters/delete_tasks_query.dart
+++ b/lib/src/query_parameters/delete_tasks_query.dart
@@ -1,0 +1,30 @@
+import 'package:meilisearch/src/query_parameters/queryable.dart';
+
+class DeleteTasksQuery extends Queryable {
+  final int? next;
+  final DateTime? beforeEnqueuedAt;
+  final DateTime? afterEnqueuedAt;
+  final DateTime? beforeStartedAt;
+  final DateTime? afterStartedAt;
+  final DateTime? beforeFinishedAt;
+  final DateTime? afterFinishedAt;
+  final List<int> canceledBy;
+  final List<int> uids;
+  final List<String> statuses;
+  final List<String> types;
+  final List<String> indexUids;
+
+  DeleteTasksQuery(
+      {this.next,
+      this.beforeEnqueuedAt,
+      this.afterEnqueuedAt,
+      this.beforeStartedAt,
+      this.afterStartedAt,
+      this.beforeFinishedAt,
+      this.afterFinishedAt,
+      this.canceledBy: const [],
+      this.uids: const [],
+      this.indexUids: const [],
+      this.statuses: const [],
+      this.types: const []});
+}

--- a/test/tasks_test.dart
+++ b/test/tasks_test.dart
@@ -1,4 +1,5 @@
 import 'package:meilisearch/src/query_parameters/cancel_tasks_query.dart';
+import 'package:meilisearch/src/query_parameters/delete_tasks_query.dart';
 import 'package:test/test.dart';
 
 import 'utils/client.dart';
@@ -12,6 +13,22 @@ void main() {
       var response = await client
           .cancelTasks(
               params: CancelTasksQuery(uids: [1, 2], beforeStartedAt: date))
+          .waitFor();
+
+      expect(response.status, 'succeeded');
+      expect(response.details!['originalFilter'],
+          '?beforeStartedAt=${Uri.encodeComponent(date.toUtc().toIso8601String())}&uids=1%2C2');
+    });
+  });
+
+  group('Delete Tasks', () {
+    setUpClient();
+
+    test('delete tasks given an input', () async {
+      var date = DateTime.now();
+      var response = await client
+          .deleteTasks(
+              params: DeleteTasksQuery(uids: [1, 2], beforeStartedAt: date))
           .waitFor();
 
       expect(response.status, 'succeeded');


### PR DESCRIPTION
- Create `DeleteTasksQuery` class to handle route's params
- Add `deleteTasks({DeleteTasksQuery? params})` method to client
- Add support to `queryParameters` in delete methods