### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,53 @@
+# 0.7.0
+### Changes
+
+- `SearchResult` now is returned from `search` requests when is a non-exhaustive pagination request. A instance of `PaginatedSearchResult` is returned when the request was made with finite pagination.
+- Add `Future<Task> swapIndexes(List<SwapIndex> swaps)` method to swap indexes.
+- Add `Future<Task> cancelTasks({CancelTasksQuery? params})` to cancel tasks based on the input query params.
+  - `CancelTasksQuery` has these fields:
+    - `int? next;`
+    - `DateTime? beforeEnqueuedAt;`
+    - `DateTime? afterEnqueuedAt;`
+    - `DateTime? beforeStartedAt;`
+    - `DateTime? afterStartedAt;`
+    - `DateTime? beforeFinishedAt;`
+    - `DateTime? afterFinishedAt;`
+    - `List<int> uids;`
+    - `List<String> statuses;`
+    - `List<String> types;`
+    - `List<String> indexUids;`
+- Add `Future<Task> deleteTasks({DeleteTasksQuery? params})` delete old processed tasks based on the input query params.
+  - `DeleteTasksQuery` has these fields:
+    - `int? next;`
+    - `DateTime? beforeEnqueuedAt;`
+    - `DateTime? afterEnqueuedAt;`
+    - `DateTime? beforeStartedAt;`
+    - `DateTime? afterStartedAt;`
+    - `DateTime? beforeFinishedAt;`
+    - `DateTime? afterFinishedAt;`
+    - `List<int> canceledBy;`
+    - `List<int> uids;`
+    - `List<String> statuses;`
+    - `List<String> types;`
+    - `List<String> indexUids;`
+
+### Breaking changes
+
+- `TasksQuery` has new fields, and some of them were renamed:
+  - those fields were added:
+    - `int? canceledBy;`
+    - `DateTime? beforeEnqueuedAt;`
+    - `DateTime? afterEnqueuedAt;`
+    - `DateTime? beforeStartedAt;`
+    - `DateTime? afterStartedAt;`
+    - `DateTime? beforeFinishedAt;`
+    - `DateTime? afterFinishedAt;`
+    - `List<int> uids;`
+  - those were renamed:
+    - `List<String> statuses;` from `List<String> status;`
+    - `List<String> types;` from `List<String> type;`
+    - `List<String> indexUids;` from `List<String> indexUid;`
+
 # 0.6.1
 ### Changes
 - Add support to `matchingStrategy` in the search `MeiliSearchIndex#search`.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can install the **meilisearch** package by adding a few lines into `pubspec.
 
 ```yaml
 dependencies:
-  meilisearch: ^0.6.1
+  meilisearch: ^0.7.0
 ```
 
 Then open your terminal and update dart packages.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   crypto:
     dependency: transitive
     description:
@@ -28,35 +28,35 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   meilisearch:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.6.1"
+    version: "0.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -72,4 +72,4 @@ packages:
     source: hosted
     version: "1.3.1"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  meilisearch: "0.6.1"
+  meilisearch: "0.7.0"
 
 dependency_overrides:
   meilisearch:

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,5 +1,5 @@
 class Version {
-  static const String current = '0.6.1';
+  static const String current = '0.7.0';
 
   static String get qualifiedVersion {
     return "Meilisearch Dart (v${current})";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: meilisearch
 description: Meilisearch Dart is the Meilisearch API client for Dart and Flutter developers.
-version: 0.6.1
+version: 0.7.0
 homepage: https://meilisearch.com
 repository: https://github.com/meilisearch/meilisearch-dart
 issue_tracker: https://github.com/meilisearch/meilisearch-dart/issues


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.30.0 :tada:
Check out the changelog of [Meilisearch v0.30.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0) for more information on the changes.

## 🚀 Enhancements

- `SearchResult` is now returned from `search` requests when it is a non-exhaustive pagination request. An instance of `PaginatedSearchResult` is returned when the request was made with finite pagination. (#230) @brunoocasali 
- Add `Future<Task> swapIndexes(List<SwapIndex> swaps)` method to swap indexes. 
- Add `Future<Task> cancelTasks({CancelTasksQuery? params})` to cancel tasks based on the input query params. (#231 ) @brunoocasali 
  - `CancelTasksQuery` has these fields:
    - `int? next;`
    - `DateTime? beforeEnqueuedAt;`
    - `DateTime? afterEnqueuedAt;`
    - `DateTime? beforeStartedAt;`
    - `DateTime? afterStartedAt;`
    - `DateTime? beforeFinishedAt;`
    - `DateTime? afterFinishedAt;`
    - `List<int> uids;`
    - `List<String> statuses;`
    - `List<String> types;`
    - `List<String> indexUids;`
- Add `Future<Task> deleteTasks({DeleteTasksQuery? params})` to delete old processed tasks based on the input query params. (#233) @brunoocasali 
  - `DeleteTasksQuery` has these fields:
    - `int? next;`
    - `DateTime? beforeEnqueuedAt;`
    - `DateTime? afterEnqueuedAt;`
    - `DateTime? beforeStartedAt;`
    - `DateTime? afterStartedAt;`
    - `DateTime? beforeFinishedAt;`
    - `DateTime? afterFinishedAt;`
    - `List<int> canceledBy;`
    - `List<int> uids;`
    - `List<String> statuses;`
    - `List<String> types;`
    - `List<String> indexUids;`

## 💥 Breaking changes

- `TasksQuery` has new fields, and some of them were renamed:
  - those fields were added:
    - `int? canceledBy;`
    - `DateTime? beforeEnqueuedAt;`
    - `DateTime? afterEnqueuedAt;`
    - `DateTime? beforeStartedAt;`
    - `DateTime? afterStartedAt;`
    - `DateTime? beforeFinishedAt;`
    - `DateTime? afterFinishedAt;`
    - `List<int> uids;`
  - those were renamed:
    - `List<String> statuses;` from `List<String> status;`
    - `List<String> types;` from `List<String> type;`
    - `List<String> indexUids;` from `List<String> indexUid;`
    
Thanks again to @brunoocasali! 🎉