### PR TITLE
Add indexUid to Task

### DIFF
--- a/lib/src/query_parameters/cancel_tasks_query.dart
+++ b/lib/src/query_parameters/cancel_tasks_query.dart
@@ -1,7 +1,6 @@
 import 'package:meilisearch/src/query_parameters/queryable.dart';
 
 class CancelTasksQuery extends Queryable {
-  final int? next;
   final DateTime? beforeEnqueuedAt;
   final DateTime? afterEnqueuedAt;
   final DateTime? beforeStartedAt;
@@ -14,8 +13,7 @@ class CancelTasksQuery extends Queryable {
   final List<String> indexUids;
 
   CancelTasksQuery(
-      {this.next,
-      this.beforeEnqueuedAt,
+      {this.beforeEnqueuedAt,
       this.afterEnqueuedAt,
       this.beforeStartedAt,
       this.afterStartedAt,
@@ -28,7 +26,6 @@ class CancelTasksQuery extends Queryable {
 
   Map<String, dynamic> buildMap() {
     return {
-      'next': this.next,
       'beforeEnqueuedAt': this.beforeEnqueuedAt,
       'afterEnqueuedAt': this.afterEnqueuedAt,
       'beforeStartedAt': this.beforeStartedAt,

--- a/lib/src/query_parameters/delete_tasks_query.dart
+++ b/lib/src/query_parameters/delete_tasks_query.dart
@@ -1,7 +1,6 @@
 import 'package:meilisearch/src/query_parameters/queryable.dart';
 
 class DeleteTasksQuery extends Queryable {
-  final int? next;
   final DateTime? beforeEnqueuedAt;
   final DateTime? afterEnqueuedAt;
   final DateTime? beforeStartedAt;
@@ -15,8 +14,7 @@ class DeleteTasksQuery extends Queryable {
   final List<String> indexUids;
 
   DeleteTasksQuery(
-      {this.next,
-      this.beforeEnqueuedAt,
+      {this.beforeEnqueuedAt,
       this.afterEnqueuedAt,
       this.beforeStartedAt,
       this.afterStartedAt,
@@ -30,7 +28,6 @@ class DeleteTasksQuery extends Queryable {
 
   Map<String, dynamic> buildMap() {
     return {
-      'next': this.next,
       'beforeEnqueuedAt': this.beforeEnqueuedAt,
       'afterEnqueuedAt': this.afterEnqueuedAt,
       'beforeStartedAt': this.beforeStartedAt,

--- a/lib/src/query_parameters/tasks_query.dart
+++ b/lib/src/query_parameters/tasks_query.dart
@@ -2,7 +2,6 @@ import 'package:meilisearch/src/query_parameters/queryable.dart';
 
 class TasksQuery extends Queryable {
   final int? from;
-  final int? next;
   final int? limit;
   final int? canceledBy;
   final DateTime? beforeEnqueuedAt;
@@ -19,7 +18,6 @@ class TasksQuery extends Queryable {
   TasksQuery(
       {this.limit,
       this.from,
-      this.next,
       this.canceledBy,
       this.beforeEnqueuedAt,
       this.afterEnqueuedAt,
@@ -35,7 +33,6 @@ class TasksQuery extends Queryable {
   Map<String, dynamic> buildMap() {
     return {
       'from': this.from,
-      'next': this.next,
       'limit': this.limit,
       'canceledBy': this.canceledBy,
       'beforeEnqueuedAt': this.beforeEnqueuedAt,

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -2,6 +2,7 @@ class Task {
   Task({
     this.status,
     this.uid,
+    this.indexUid,
     this.type,
     this.duration,
     this.enqueuedAt,
@@ -12,6 +13,7 @@ class Task {
 
   final String? status;
   final int? uid;
+  final String? indexUid;
   final String? type;
   final String? duration;
   final DateTime? enqueuedAt;
@@ -22,6 +24,7 @@ class Task {
   factory Task.fromMap(Map<String, dynamic> map) => Task(
         status: map['status'] as String?,
         uid: (map['uid'] ?? map['taskUid']) as int,
+        indexUid: map['indexUid'],
         duration: map['duration'] as String?,
         enqueuedAt: map['enqueuedAt'] != null
             ? DateTime.tryParse(map['enqueuedAt'] as String)

--- a/test/dump_test.dart
+++ b/test/dump_test.dart
@@ -7,10 +7,11 @@ void main() {
     setUpClient();
 
     test('creates a dump', () async {
-      final dump = await client.createDump();
+      final task = await client.createDump();
 
-      expect(dump.type, equals('dumpCreation'));
-      expect(dump.status, anyOf('succeeded', 'enqueued'));
+      expect(task.type, equals('dumpCreation'));
+      expect(task.status, anyOf('succeeded', 'enqueued'));
+      expect(task.indexUid, isNull);
     });
   });
 }

--- a/test/indexes_test.dart
+++ b/test/indexes_test.dart
@@ -176,5 +176,14 @@ void main() {
       expect(() async => await index.getTask(9999),
           throwsA(isA<MeiliSearchApiException>()));
     });
+
+    test('extracts all possible properties from task', () async {
+      final uid = randomUid();
+      final task = await client.createIndex(uid);
+
+      expect(task.uid, greaterThan(0));
+      expect(task.indexUid, equals(uid));
+      expect(task.type, equals("indexCreation"));
+    });
   });
 }


### PR DESCRIPTION
Fixes #202 

Also, removes `next` from `DeleteTasksQuery`, `CancelTasksQuery` and `TasksQuery`.