### PR TITLE
Update the version for the next release (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 0.8.0
+### Breaking changes
+
+- `TasksQuery#canceledBy` field is now a `List<int>` and not an `int?` anymore.
+
+### Changes
+
+- Expose these classes:
+  - `PaginatedSearchResult`
+  - `DocumentsQuery`
+  - `TasksQuery`
+  - `CancelTasksQuery`
+  - `DeleteTasksQuery`
+  - `KeysTasksQuery`
+  - `IndexesTasksQuery`
+  - `MatchingStrategy` enum
+  - `MeiliSearchApiException` and `CommunicationException`
+  - `Task` and `TaskError`
+  - `SwapIndex`
+
 # 0.7.1
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can install the **meilisearch** package by adding a few lines into `pubspec.
 
 ```yaml
 dependencies:
-  meilisearch: ^0.7.1
+  meilisearch: ^0.8.0
 ```
 
 Then open your terminal and update dart packages.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.7.1"
+    version: "0.8.0"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  meilisearch: "0.7.1"
+  meilisearch: "0.8.0"
 
 dependency_overrides:
   meilisearch:

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,5 +1,5 @@
 class Version {
-  static const String current = '0.7.1';
+  static const String current = '0.8.0';
 
   static String get qualifiedVersion {
     return "Meilisearch Dart (v${current})";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: meilisearch
 description: Meilisearch Dart is the Meilisearch API client for Dart and Flutter developers.
-version: 0.7.1
+version: 0.8.0
 homepage: https://meilisearch.com
 repository: https://github.com/meilisearch/meilisearch-dart
 issue_tracker: https://github.com/meilisearch/meilisearch-dart/issues


### PR DESCRIPTION
Changelog:

# 0.8.0
### Breaking changes

- `TasksQuery#canceledBy` field is now a `List<int>` and not an `int?` anymore.

### Changes

- Expose these classes:
  - `PaginatedSearchResult`
  - `DocumentsQuery`
  - `TasksQuery`
  - `CancelTasksQuery`
  - `DeleteTasksQuery`
  - `KeysTasksQuery`
  - `IndexesTasksQuery`
  - `MatchingStrategy` enum
  - `MeiliSearchApiException` and `CommunicationException`
  - `Task` and `TaskError`
  - `SwapIndex`