### PR TITLE
Fix createKey with uid

### DIFF
--- a/lib/src/client_impl.dart
+++ b/lib/src/client_impl.dart
@@ -170,6 +170,7 @@ class MeiliSearchClientImpl implements MeiliSearchClient {
       required List<String> indexes,
       required List<String> actions}) async {
     final data = <String, dynamic>{
+      if (uid != null) 'uid': uid,
       'expiresAt': expiresAt?.toIso8601String().split('.').first,
       if (description != null) 'description': description,
       'indexes': indexes,

--- a/test/get_keys_test.dart
+++ b/test/get_keys_test.dart
@@ -52,6 +52,7 @@ void main() {
             actions: ["documents.add"],
             indexes: ["movies"]);
 
+        expect(key.uid, equals("8dbfeeee-65d4-4de2-b4cc-2b981d58d112"));
         expect(key.description, equals("awesome-key"));
         expect(key.actions, equals(["documents.add"]));
         expect(key.indexes, equals(["movies"]));


### PR DESCRIPTION
Reviewing the [PR](https://github.com/meilisearch/meilisearch-dart/pull/249) made me realize we were not using the `uid` properly neither was the test asserting the value. 

This PR fixes it.