### PR TITLE
Fixes flaky test on tenant_tokens_test.dart

### DIFF
--- a/test/tenant_token_test.dart
+++ b/test/tenant_token_test.dart
@@ -56,14 +56,13 @@ void main() {
         final admClient = MeiliSearchClient(testServer, admKey.key);
         final index = await createBooksIndex(uid: 'my_index');
         await index.updateFilterableAttributes(['tag', 'book_id']).waitFor(
-            client: client);
+          client: client,
+        );
 
         for (final Object rule in possibleRules) {
           final token = admClient.generateTenantToken(admKey.uid!, rule);
           final custom = MeiliSearchClient(testServer, token);
-
-          expect(() async => await custom.index('my_index').search(''),
-              returnsNormally);
+          await custom.index('my_index').search('');
         }
       });
     });

--- a/test/tenant_token_test.dart
+++ b/test/tenant_token_test.dart
@@ -59,7 +59,7 @@ void main() {
           client: client,
         );
 
-        Future.wait(
+        await Future.wait(
           possibleRules.map((rule) {
             final token = admClient.generateTenantToken(admKey.uid!, rule);
             final custom = MeiliSearchClient(testServer, token);

--- a/test/tenant_token_test.dart
+++ b/test/tenant_token_test.dart
@@ -59,11 +59,13 @@ void main() {
           client: client,
         );
 
-        for (final Object rule in possibleRules) {
-          final token = admClient.generateTenantToken(admKey.uid!, rule);
-          final custom = MeiliSearchClient(testServer, token);
-          await custom.index('my_index').search('');
-        }
+        Future.wait(
+          possibleRules.map((rule) {
+            final token = admClient.generateTenantToken(admKey.uid!, rule);
+            final custom = MeiliSearchClient(testServer, token);
+            return custom.index('my_index').search('');
+          }),
+        );
       });
     });
 


### PR DESCRIPTION
Fixes #246 

The problem is that `expect` is a void that completes instantly without waiting for the called async function to complete.
this means that all the expect tests will process in parallel instantly, which means the `teardown` function might get called before they finish, leading to `my_index` getting deleted while the tests haven't concluded.