### PR TITLE
fixes getTasks modifying passed indexUids

### DIFF
--- a/lib/src/index_impl.dart
+++ b/lib/src/index_impl.dart
@@ -660,7 +660,9 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
     if (params == null) {
       params = TasksQuery(indexUids: [uid]);
     } else {
-      params.indexUids.add(uid);
+      if (!params.indexUids.contains(uid)) {
+        params = params.copyWith(indexUids: [...params.indexUids, uid]);
+      }
     }
 
     return await client.getTasks(params: params);

--- a/lib/src/query_parameters/tasks_query.dart
+++ b/lib/src/query_parameters/tasks_query.dart
@@ -31,6 +31,30 @@ class TasksQuery extends Queryable {
     this.types = const [],
   });
 
+  TasksQuery copyWith({
+    List<int>? uids,
+    List<int>? canceledBy,
+    List<String>? statuses,
+    List<String>? types,
+    List<String>? indexUids,
+  }) {
+    return TasksQuery(
+      from: from,
+      limit: limit,
+      beforeEnqueuedAt: beforeEnqueuedAt,
+      afterEnqueuedAt: afterEnqueuedAt,
+      beforeStartedAt: beforeStartedAt,
+      afterStartedAt: afterStartedAt,
+      beforeFinishedAt: beforeFinishedAt,
+      afterFinishedAt: afterFinishedAt,
+      uids: uids ?? this.uids,
+      canceledBy: canceledBy ?? this.canceledBy,
+      statuses: statuses ?? this.statuses,
+      types: types ?? this.types,
+      indexUids: indexUids ?? this.indexUids,
+    );
+  }
+
   Map<String, Object?> buildMap() {
     return {
       'from': from,

--- a/test/tasks_test.dart
+++ b/test/tasks_test.dart
@@ -1,7 +1,6 @@
 import 'package:meilisearch/meilisearch.dart';
 import 'package:test/test.dart';
 
-import 'utils/books.dart';
 import 'utils/books_data.dart';
 import 'utils/client.dart';
 import 'utils/wait_for.dart';


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #273 

## What does this PR do?
- Introduces a new limited `copyWith` on `TasksQuery` to use to ensure index uid is present, instead of modifying original `indexUids` which by default is const

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

cc @brunoocasali 