### PR TITLE
fix pre-release-tests.yml to use v2.15.1 and 2.19.0 like the rest

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version: [
-          '2.12',
-          '2.17',
+          '2.15.1',
+          '2.19.0',
         ]
     name: integration-tests-against-rc (dart ${{ matrix.version }})
     steps:


### PR DESCRIPTION
# Pull Request

## Related issue
fixes the reason https://github.com/meilisearch/meilisearch-dart/pull/267 is failing CI

## What does this PR do?
- Fixes `pre-release-tests.yml` to use 2.15.1 and 2.19.0 of the dart sdk

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
