### PR TITLE
More Improvements for Typed search results

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -66,8 +66,8 @@ abstract class MeiliSearchClient {
   Future<MeiliSearchIndex> getIndex(String uid);
 
   /// Find index by matching [uid] and responds with raw information from API.
-  /// Throws error if index is not exists.
-  Future<Map<String, dynamic>> getRawIndex(String uid);
+  /// Throws error if index does not exist.
+  Future<Map<String, Object?>> getRawIndex(String uid);
 
   /// Create a new index by given [uid] and optional [primaryKey] parameter.
   /// Throws an error if index is already exists.

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -67,7 +67,7 @@ abstract class MeiliSearchClient {
 
   /// Find index by matching [uid] and responds with raw information from API.
   /// Throws error if index is not exists.
-  Future<Map<String, Object?>> getRawIndex(String uid);
+  Future<Map<String, dynamic>> getRawIndex(String uid);
 
   /// Create a new index by given [uid] and optional [primaryKey] parameter.
   /// Throws an error if index is already exists.
@@ -84,7 +84,7 @@ abstract class MeiliSearchClient {
 
   /// Return health of the Meilisearch server.
   /// Throws an error if containing details if Meilisearch can't process your request.
-  Future<Map<String, Object?>> health();
+  Future<Map<String, dynamic>> health();
 
   /// Get health of the Meilisearch server.
   /// Return true or false.

--- a/lib/src/client_impl.dart
+++ b/lib/src/client_impl.dart
@@ -78,14 +78,14 @@ class MeiliSearchClientImpl implements MeiliSearchClient {
   }
 
   @override
-  Future<Map<String, Object?>> getRawIndex(String uid) async {
+  Future<Map<String, dynamic>> getRawIndex(String uid) async {
     final response = await _getIndex(uid);
 
     return response.data!;
   }
 
-  Future<Response<Map<String, Object?>>> _getIndex(String uid) {
-    return http.getMethod<Map<String, Object?>>('/indexes/$uid');
+  Future<Response<Map<String, dynamic>>> _getIndex(String uid) {
+    return http.getMethod<Map<String, dynamic>>('/indexes/$uid');
   }
 
   @override
@@ -122,8 +122,8 @@ class MeiliSearchClientImpl implements MeiliSearchClient {
   }
 
   @override
-  Future<Map<String, Object?>> health() async {
-    final response = await http.getMethod<Map<String, Object?>>('/health');
+  Future<Map<String, dynamic>> health() async {
+    final response = await http.getMethod<Map<String, dynamic>>('/health');
 
     return response.data!;
   }

--- a/lib/src/client_impl.dart
+++ b/lib/src/client_impl.dart
@@ -78,13 +78,13 @@ class MeiliSearchClientImpl implements MeiliSearchClient {
   }
 
   @override
-  Future<Map<String, dynamic>> getRawIndex(String uid) async {
+  Future<Map<String, Object?>> getRawIndex(String uid) async {
     final response = await _getIndex(uid);
 
     return response.data!;
   }
 
-  Future<Response<Map<String, dynamic>>> _getIndex(String uid) {
+  Future<Response<Map<String, Object?>>> _getIndex(String uid) {
     return http.getMethod<Map<String, dynamic>>('/indexes/$uid');
   }
 

--- a/lib/src/http_request.dart
+++ b/lib/src/http_request.dart
@@ -20,7 +20,7 @@ abstract class HttpRequest {
   Duration? get connectTimeout;
 
   /// Retrieve all headers used when Http calls are made.
-  Map<String, Object?> headers();
+  Map<String, dynamic> headers();
 
   /// GET method
   Future<Response<T>> getMethod<T>(

--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -18,13 +18,13 @@ abstract class MeiliSearchIndex {
   set primaryKey(String? primaryKey);
 
   /// Update the primary Key of the index.
-  Future<Task> update({String primaryKey});
+  Future<Task> update({String? primaryKey});
 
   /// Delete the index.
   Future<Task> delete();
 
   /// Search for documents matching a specific query in the index.
-  Future<Searcheable<Map<String, Object?>>> search(
+  Future<Searcheable<Map<String, dynamic>>> search(
     String? query, {
     int? offset,
     int? limit,
@@ -48,10 +48,10 @@ abstract class MeiliSearchIndex {
   });
 
   /// Return the document in the index by given [id].
-  Future<Map<String, Object?>?> getDocument(Object id, {List<String> fields});
+  Future<Map<String, dynamic>?> getDocument(Object id, {List<String> fields});
 
   /// Return a list of all existing documents in the index.
-  Future<Result<Map<String, Object?>>> getDocuments({DocumentsQuery? params});
+  Future<Result<Map<String, dynamic>>> getDocuments({DocumentsQuery? params});
 
   /// {@template meili.add_docs}
   /// Add a list of documents by given [documents] and optional [primaryKey] parameter.

--- a/lib/src/index_impl.dart
+++ b/lib/src/index_impl.dart
@@ -107,7 +107,7 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
   //
 
   @override
-  Future<Searcheable<Map<String, Object?>>> search(
+  Future<Searcheable<Map<String, dynamic>>> search(
     String? query, {
     int? offset,
     int? limit,
@@ -223,7 +223,7 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
 
   @override
   Future<List<Task>> addDocumentsInBatches(
-    List<Map<String, Object?>> documents, {
+    List<Map<String, dynamic>> documents, {
     int batchSize = 1000,
     String? primaryKey,
   }) =>
@@ -401,10 +401,10 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
   }
 
   @override
-  Future<Map<String, Object?>?> getDocument(Object id,
+  Future<Map<String, dynamic>?> getDocument(Object id,
       {List<String> fields = const []}) async {
     final params = DocumentsQuery(fields: fields);
-    final response = await http.getMethod<Map<String, Object?>>(
+    final response = await http.getMethod<Map<String, dynamic>>(
         '/indexes/$uid/documents/$id',
         queryParameters: params.toQuery());
 
@@ -412,7 +412,7 @@ class MeiliSearchIndexImpl implements MeiliSearchIndex {
   }
 
   @override
-  Future<Result<Map<String, Object?>>> getDocuments(
+  Future<Result<Map<String, dynamic>>> getDocuments(
       {DocumentsQuery? params}) async {
     final response = await http.getMethod<Map<String, Object?>>(
         '/indexes/$uid/documents',

--- a/lib/src/paginated_search_result.dart
+++ b/lib/src/paginated_search_result.dart
@@ -2,7 +2,7 @@ import 'package:meilisearch/src/searchable.dart';
 
 class PaginatedSearchResult<T> extends Searcheable<T> {
   const PaginatedSearchResult({
-    List<T>? hits,
+    List<T> hits = const [],
     Object? facetDistribution,
     Object? matchesPosition,
     int? processingTimeMs,
@@ -33,7 +33,7 @@ class PaginatedSearchResult<T> extends Searcheable<T> {
   /// Total number of pages
   final int? totalPages;
 
-  static PaginatedSearchResult<Map<String, Object?>> fromMap(
+  static PaginatedSearchResult<Map<String, dynamic>> fromMap(
     Map<String, Object?> map, {
     String? indexUid,
   }) {
@@ -42,7 +42,7 @@ class PaginatedSearchResult<T> extends Searcheable<T> {
       hitsPerPage: map['hitsPerPage'] as int?,
       totalHits: map['totalHits'] as int?,
       totalPages: map['totalPages'] as int?,
-      hits: (map['hits'] as List?)?.cast<Map<String, Object?>>(),
+      hits: (map['hits'] as List?)?.cast<Map<String, Object?>>() ?? [],
       query: map['query'] as String?,
       processingTimeMs: map['processingTimeMs'] as int?,
       facetDistribution: map['facetDistribution'],
@@ -52,13 +52,13 @@ class PaginatedSearchResult<T> extends Searcheable<T> {
   }
 
   @override
-  PaginatedSearchResult<TOther> cast<TOther>(
+  PaginatedSearchResult<TOther> map<TOther>(
     MeilisearchDocumentMapper<T, TOther> mapper,
   ) {
     return PaginatedSearchResult<TOther>(
       indexUid: indexUid,
       facetDistribution: facetDistribution,
-      hits: hits?.map(mapper).toList(),
+      hits: hits.map(mapper).toList(),
       hitsPerPage: hitsPerPage,
       matchesPosition: matchesPosition,
       page: page,

--- a/lib/src/search_result.dart
+++ b/lib/src/search_result.dart
@@ -2,7 +2,7 @@ import 'package:meilisearch/src/searchable.dart';
 
 class SearchResult<T> extends Searcheable<T> {
   const SearchResult({
-    List<T>? hits,
+    List<T> hits = const [],
     Object? facetDistribution,
     Object? matchesPosition,
     int? processingTimeMs,
@@ -29,7 +29,7 @@ class SearchResult<T> extends Searcheable<T> {
   /// Estimated number of matches
   final int? estimatedTotalHits;
 
-  static SearchResult<Map<String, Object?>> fromMap(
+  static SearchResult<Map<String, dynamic>> fromMap(
     Map<String, Object?> map, {
     String? indexUid,
   }) {
@@ -37,7 +37,7 @@ class SearchResult<T> extends Searcheable<T> {
       limit: map['limit'] as int?,
       offset: map['offset'] as int?,
       estimatedTotalHits: map['estimatedTotalHits'] as int?,
-      hits: (map['hits'] as List?)?.cast<Map<String, Object?>>(),
+      hits: (map['hits'] as List?)?.cast<Map<String, Object?>>() ?? [],
       query: map['query'] as String?,
       processingTimeMs: map['processingTimeMs'] as int?,
       facetDistribution: map['facetDistribution'],
@@ -47,13 +47,13 @@ class SearchResult<T> extends Searcheable<T> {
   }
 
   @override
-  SearchResult<TOther> cast<TOther>(
+  SearchResult<TOther> map<TOther>(
     MeilisearchDocumentMapper<T, TOther> mapper,
   ) {
     return SearchResult<TOther>(
       indexUid: indexUid,
       facetDistribution: facetDistribution,
-      hits: hits?.map(mapper).toList(),
+      hits: hits.map(mapper).toList(),
       estimatedTotalHits: estimatedTotalHits,
       limit: limit,
       offset: offset,

--- a/lib/src/searchable.dart
+++ b/lib/src/searchable.dart
@@ -9,7 +9,7 @@ abstract class Searcheable<T> {
   final String? query;
 
   /// Results of the query
-  final List<T>? hits;
+  final List<T> hits;
 
   /// Distribution of the given facets
   final Object? facetDistribution;
@@ -23,13 +23,13 @@ abstract class Searcheable<T> {
   const Searcheable({
     required this.indexUid,
     this.query,
-    this.hits,
+    this.hits = const [],
     this.facetDistribution,
     this.matchesPosition,
     this.processingTimeMs,
   });
 
-  static Searcheable<Map<String, Object?>> createSearchResult(
+  static Searcheable<Map<String, dynamic>> createSearchResult(
     Map<String, Object?> map, {
     String? indexUid,
   }) {
@@ -40,7 +40,7 @@ abstract class Searcheable<T> {
     }
   }
 
-  Searcheable<TOther> cast<TOther>(MeilisearchDocumentMapper<T, TOther> mapper);
+  Searcheable<TOther> map<TOther>(MeilisearchDocumentMapper<T, TOther> mapper);
 
   PaginatedSearchResult<T> asPaginatedResult() {
     final src = this;
@@ -53,4 +53,31 @@ abstract class Searcheable<T> {
     assert(src is SearchResult<T>);
     return src as SearchResult<T>;
   }
+}
+
+extension SearchableExt<T> on Future<Searcheable<T>> {
+  Future<PaginatedSearchResult<T>> asPaginatedResult() =>
+      then((value) => value.asPaginatedResult());
+
+  Future<SearchResult<T>> asSearchResult() =>
+      then((value) => value.asSearchResult());
+
+  Future<Searcheable<TOther>> cast<TOther>(
+    MeilisearchDocumentMapper<T, TOther> mapper,
+  ) =>
+      then((value) => value.map(mapper));
+}
+
+extension SearchResultExt<T> on Future<SearchResult<T>> {
+  Future<SearchResult<TOther>> cast<TOther>(
+    MeilisearchDocumentMapper<T, TOther> mapper,
+  ) =>
+      then((value) => value.map(mapper));
+}
+
+extension PaginatedSearchResultExt<T> on Future<PaginatedSearchResult<T>> {
+  Future<PaginatedSearchResult<TOther>> cast<TOther>(
+    MeilisearchDocumentMapper<T, TOther> mapper,
+  ) =>
+      then((value) => value.map(mapper));
 }

--- a/test/multi_index_search_test.dart
+++ b/test/multi_index_search_test.dart
@@ -41,10 +41,10 @@ void main() {
       expect(result.results, hasLength(2));
       //test first result
       expect(result.results.first.indexUid, index1.uid);
-      expect(result.results.first.hits!.length, 1);
+      expect(result.results.first.hits.length, 1);
       //test second result
       expect(result.results.last.indexUid, index2.uid);
-      expect(result.results.last.hits!.length, 2);
+      expect(result.results.last.hits.length, 2);
     });
   });
 }

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -1,4 +1,5 @@
 import 'package:meilisearch/meilisearch.dart';
+import 'package:meilisearch/src/searchable.dart';
 import 'package:test/test.dart';
 
 import 'utils/books.dart';
@@ -13,11 +14,10 @@ void main() {
     test('cast', () async {
       final index = await createBooksIndex();
       //search
-      final result =
-          await index.search('').then((value) => value.asSearchResult());
-      //test
       //if deserialization fails it will throw
-      final castedResult = result.cast(BookDto.fromMap);
+      final castedResult =
+          await index.search('').asSearchResult().cast(BookDto.fromMap);
+      //test
       expect(castedResult.hits, everyElement(isA<BookDto>()));
     });
 
@@ -66,7 +66,7 @@ void main() {
           cropLength: 2,
         );
         expect(
-          (result.hits![0]['_formatted'] as Map<String, Object?>)['title'],
+          result.hits[0]['_formatted']['title'],
           equals('Alice In…'),
         );
       });
@@ -76,8 +76,7 @@ void main() {
         var result = await index.search('prince',
             attributesToCrop: ['*'], cropLength: 2);
 
-        expect((result.hits![0]['_formatted'] as Map<String, Object?>)['title'],
-            equals('…Petit Prince'));
+        expect(result.hits[0]['_formatted']['title'], equals('…Petit Prince'));
       });
 
       test('searches with custom cropMarker', () async {
@@ -85,8 +84,7 @@ void main() {
         var result = await index.search('prince',
             attributesToCrop: ['*'], cropLength: 1, cropMarker: '[…] ');
 
-        expect((result.hits![0]['_formatted'] as Map<String, Object?>)['title'],
-            equals('[…] Prince'));
+        expect(result.hits[0]['_formatted']['title'], equals('[…] Prince'));
       });
 
       test('searches with custom highlight tags', () async {
@@ -96,7 +94,7 @@ void main() {
             highlightPreTag: '<mark>',
             highlightPostTag: '</mark>');
 
-        expect((result.hits![0]['_formatted'] as Map<String, Object?>)['title'],
+        expect(result.hits[0]['_formatted']['title'],
             equals('Harry Potter and the Half-<mark>Blood</mark> Prince'));
       });
 
@@ -107,7 +105,7 @@ void main() {
           matchingStrategy: MatchingStrategy.last,
         );
 
-        expect(result.hits!.last['title'],
+        expect(result.hits.last['title'],
             equals('Harry Potter and the Half-Blood Prince'));
       });
 
@@ -118,7 +116,7 @@ void main() {
           matchingStrategy: MatchingStrategy.all,
         );
 
-        expect(result.hits!.last['title'],
+        expect(result.hits.last['title'],
             equals('The Hitchhiker\'s Guide to the Galaxy'));
       });
 
@@ -128,7 +126,7 @@ void main() {
           'the to',
         );
 
-        expect(result.hits!.last['title'],
+        expect(result.hits.last['title'],
             equals('Harry Potter and the Half-Blood Prince'));
       });
 
@@ -251,7 +249,7 @@ void main() {
         expect(response.status, 'succeeded');
         var result = await index.search('prince', sort: ['title:asc']);
         expect(result.hits, hasLength(2));
-        expect(result.hits![0]['book_id'], 4);
+        expect(result.hits[0]['book_id'], 4);
       });
     });
 
@@ -259,7 +257,7 @@ void main() {
       var index = await createNestedBooksIndex();
       var response = await index.search('An awesome');
 
-      expect(response.hits![0], {
+      expect(response.hits[0], {
         "id": 5,
         "title": 'The Hobbit',
         "info": {
@@ -279,7 +277,7 @@ void main() {
 
       var response = await index.search('An awesome');
 
-      expect(response.hits![0], {
+      expect(response.hits[0], {
         "id": 5,
         "title": 'The Hobbit',
         "info": {
@@ -299,7 +297,7 @@ void main() {
 
       var response = await index.search('', sort: ['info.reviewNb:desc']);
 
-      expect(response.hits![0], {
+      expect(response.hits[0], {
         "id": 6,
         "title": 'Harry Potter and the Half-Blood Prince',
         "info": {
@@ -322,7 +320,7 @@ void main() {
       var index = await createBooksIndex();
       var result = await index.search('pri', page: 1) as PaginatedSearchResult;
 
-      expect(result.hits!.length, greaterThanOrEqualTo(1));
+      expect(result.hits.length, greaterThanOrEqualTo(1));
       expect(result.totalPages, 1);
     });
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Revert some of the `Object?` types that were changed in https://github.com/meilisearch/meilisearch-dart/pull/249 back to `dynamic` for easier upcasting for package consumers
    e.g.: instead of 
    ```dart
    (result.hits[0]['_formatted'] as Map<String, Object?>)['title']
    ```
    you can do 
    ```dart
    result.hits[0]['_formatted']['title']
    ```
- Rename `cast` introduced in https://github.com/meilisearch/meilisearch-dart/pull/286 to `map`, which aligns with the naming of the `Result<T>` class 
- [Semi-Breaking] `Searcheable<T>.hits` is non-nullable now, and defaults to `const []`
    old:
    ```dart
    result.hits?[0]['title']
    //OR
    result.hits![0]['title']
    ```
    new:
    ```dart
    result.hits[0]['title']
    ```
- Introduced new extension methods to help consumers cast `Future<Searchable<T>>` to the corresponding type
    old:
    ```dart
    final result = await index.search('').then((value) => (value as SearchResult<Map<String,dynamic>>).map(BookDto.fromMap));
    final resultPaginated = await index.search('').then((value) => (value as PaginatedSearchResult<Map<String,dynamic>>).map(BookDto.fromMap));
    ```
    new:
    ```dart
    final result = await index.search('').asSearchResult().map(BookDto.fromMap);
    final resultPaginated = await index.search('').asPaginatedResult().map(BookDto.fromMap);
    ```
    = more readability :)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

cc @brunoocasali 
