### PR TITLE
support `_geoBoundingBox` in `filterExpression` parameter

### DIFF
--- a/lib/src/facade.dart
+++ b/lib/src/facade.dart
@@ -76,6 +76,20 @@ class Meili {
         distanceInMeters,
       );
 
+  //TODO(ahmednfwela): rework this method after Dart 3 lands with patterns
+  static MeiliGeoBoundingBoxOperatorExpression geoBoundingBox(
+    double lat1,
+    double lng1,
+    double lat2,
+    double lng2,
+  ) =>
+      MeiliGeoBoundingBoxOperatorExpression(
+        lat1,
+        lng1,
+        lat2,
+        lng2,
+      );
+
   static MeiliExistsOperatorExpression exists(
           MeiliAttributeExpression attribute) =>
       MeiliExistsOperatorExpression(attribute);

--- a/lib/src/filter_builder/operators.dart
+++ b/lib/src/filter_builder/operators.dart
@@ -110,6 +110,27 @@ class MeiliGeoRadiusOperatorExpression extends MeiliOperatorExpressionBase {
   }
 }
 
+//TODO(ahmednfwela): rework this class after Dart 3 lands with patterns
+class MeiliGeoBoundingBoxOperatorExpression
+    extends MeiliOperatorExpressionBase {
+  final double lat1;
+  final double lng1;
+  final double lat2;
+  final double lng2;
+
+  const MeiliGeoBoundingBoxOperatorExpression(
+    this.lat1,
+    this.lng1,
+    this.lat2,
+    this.lng2,
+  );
+
+  @override
+  String transform() {
+    return '_geoBoundingBox([$lat1,$lng1],[$lat2,$lng2])';
+  }
+}
+
 class MeiliExistsOperatorExpression extends MeiliOperatorExpressionBase {
   final MeiliAttributeExpression attribute;
 


### PR DESCRIPTION
# Pull Request

## Related issue
Related to https://github.com/meilisearch/meilisearch-dart/pull/267

## What does this PR do?
- this adds support for `_geoBoundingBox` in `filterExpression`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

cc @brunoocasali 
