### PR TITLE
make `query` parameter optional in `IndexSearchQuery`

### DIFF
--- a/lib/src/http_request.dart
+++ b/lib/src/http_request.dart
@@ -65,7 +65,7 @@ class HttpRequest {
         queryParameters: queryParameters,
         data: data,
       );
-    } on DioError catch (e) {
+    } on DioException catch (e) {
       return _throwException(e);
     }
   }
@@ -86,7 +86,7 @@ class HttpRequest {
           contentType: contentType,
         ),
       );
-    } on DioError catch (e) {
+    } on DioException catch (e) {
       return _throwException(e);
     }
   }
@@ -107,7 +107,7 @@ class HttpRequest {
           contentType: contentType,
         ),
       );
-    } on DioError catch (e) {
+    } on DioException catch (e) {
       return _throwException(e);
     }
   }
@@ -128,7 +128,7 @@ class HttpRequest {
           contentType: contentType,
         ),
       );
-    } on DioError catch (e) {
+    } on DioException catch (e) {
       return _throwException(e);
     }
   }
@@ -145,14 +145,14 @@ class HttpRequest {
         data: data,
         queryParameters: queryParameters,
       );
-    } on DioError catch (e) {
+    } on DioException catch (e) {
       return _throwException(e);
     }
   }
 
-  Never _throwException(DioError e) {
+  Never _throwException(DioException e) {
     final message = e.message ?? '';
-    if (e.type == DioErrorType.badResponse) {
+    if (e.type == DioExceptionType.badResponse) {
       throw MeiliSearchApiException.fromHttpBody(message, e.response?.data);
     } else {
       throw CommunicationException(message);

--- a/lib/src/query_parameters/index_search_query.dart
+++ b/lib/src/query_parameters/index_search_query.dart
@@ -10,7 +10,7 @@ class IndexSearchQuery extends SearchQuery {
 
   const IndexSearchQuery({
     required this.indexUid,
-    required this.query,
+    this.query,
     super.offset,
     super.limit,
     super.page,

--- a/test/multi_index_search_test.dart
+++ b/test/multi_index_search_test.dart
@@ -31,8 +31,7 @@ void main() {
           filterExpression:
               ktag.toMeiliAttribute().eq("Romance".toMeiliValue()),
         ),
-        IndexSearchQuery(
-          query: "",
+        IndexSearchQuery(          
           indexUid: index2.uid,
           filterExpression: ktag.toMeiliAttribute().eq("Tale".toMeiliValue()),
         ),

--- a/test/multi_index_search_test.dart
+++ b/test/multi_index_search_test.dart
@@ -31,7 +31,7 @@ void main() {
           filterExpression:
               ktag.toMeiliAttribute().eq("Romance".toMeiliValue()),
         ),
-        IndexSearchQuery(          
+        IndexSearchQuery(
           indexUid: index2.uid,
           filterExpression: ktag.toMeiliAttribute().eq("Tale".toMeiliValue()),
         ),


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #321 

## What does this PR do?
- make `query` parameter optional in `IndexSearchQuery`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
