### PR TITLE
[FIX]: Remove duplicated key in code-samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -134,8 +134,6 @@ delete_an_index_1: |-
   await client.index('movies').delete();
 get_one_document_1: |-
   await client.index('movies').getDocument(25684, fields: ['id', 'title', 'poster', 'release_date']);
-get_documents_1: |-
-  await client.index('movies').getDocuments(params: DocumentsQuery(limit: 2));
 add_or_replace_documents_1: |-
   await client.index('movies').addDocuments([
     {


### PR DESCRIPTION
# Pull Request

Hey team, found this error when building the website, hope you can give it a review 🙏🏼 
Thanks!

## What does this PR do?
- Removes duplicated key `get_documents_1` from `.code-samples.meilisearch.yaml`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
