### PR TITLE
Rename current_mean and current_sigma for AI feature

### DIFF
--- a/lib/src/settings/distribution.dart
+++ b/lib/src/settings/distribution.dart
@@ -5,27 +5,27 @@
 class DistributionShift {
   /// Value where the results are "packed".
   /// Similarity scores are translated so that they are packed around 0.5 instead
-  final double currentMean;
+  final double mean;
 
   /// standard deviation of a similarity score.
   ///
   /// Set below 0.4 to make the results less packed around the mean, and above 0.4 to make them more packed.
-  final double currentSigma;
+  final double sigma;
 
   DistributionShift({
-    required this.currentMean,
-    required this.currentSigma,
+    required this.mean,
+    required this.sigma,
   });
 
   factory DistributionShift.fromMap(Map<String, Object?> map) {
     return DistributionShift(
-      currentMean: map['current_mean'] as double,
-      currentSigma: map['current_sigma'] as double,
+      mean: map['mean'] as double,
+      sigma: map['sigma'] as double,
     );
   }
 
   Map<String, Object?> toMap() => {
-        'current_mean': currentMean,
-        'current_sigma': currentSigma,
+        'mean': mean,
+        'sigma': sigma,
       };
 }

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -604,8 +604,8 @@ void main() {
             binaryQuantized: true,
             dimensions: 100,
             distribution: DistributionShift(
-              currentMean: 20,
-              currentSigma: 5,
+              mean: 20,
+              sigma: 5,
             ),
             url: 'https://example.com',
             documentTemplateMaxBytes: 200,
@@ -619,8 +619,8 @@ void main() {
             'documentTemplate': 'a book titled {{ doc.title }}',
             'dimensions': 100,
             'distribution': {
-              'current_mean': 20,
-              'current_sigma': 5,
+              'mean': 20,
+              'sigma': 5,
             },
             'url': 'https://example.com',
             'documentTemplateMaxBytes': 200,
@@ -635,8 +635,8 @@ void main() {
           expect(
               deserialized.documentTemplate, 'a book titled {{ doc.title }}');
           expect(deserialized.dimensions, 100);
-          expect(deserialized.distribution?.currentMean, 20);
-          expect(deserialized.distribution?.currentSigma, 5);
+          expect(deserialized.distribution?.mean, 20);
+          expect(deserialized.distribution?.sigma, 5);
           expect(deserialized.url, 'https://example.com');
           expect(deserialized.documentTemplateMaxBytes, 200);
           expect(deserialized.binaryQuantized, true);


### PR DESCRIPTION
# Pull Request

## Related issue
as discussed on discord, the openapi file incorrectly contains `current_sigma` and `current_mean` when they should just be `sigma` and `mean`

## What does this PR do?
fixes https://github.com/meilisearch/meilisearch-dart/pull/398

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
