### PR TITLE
Fix CI for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   publishing:
+    permissions:
+      id-token: write # Required for authentication using OIDC
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -14,8 +16,4 @@ jobs:
       - name: Check release validity
         run: sh .github/scripts/check-release.sh
       - name: Publish
-        uses: k-paxian/dart-package-publisher@master
-        with:
-          accessToken: ${{ secrets.OAUTH_ACCESS_TOKEN }}
-          refreshToken: ${{ secrets.OAUTH_REFRESH_TOKEN }}
-          skipTests: true
+        uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
Try to fix CI to publish following this docs https://dart.dev/tools/pub/automated-publishing#configuring-a-github-action-workflow-for-publishing-to-pub-dev

I activated the settings on pub.dev

<img width="934" alt="Capture d’écran 2025-04-24 à 15 00 26" src="https://github.com/user-attachments/assets/62fb129a-7c1e-49d4-9d3f-2713b76de551" />
