### PR TITLE
Update publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,14 +6,16 @@ on:
       - v*
 
 jobs:
-  publishing:
-    permissions:
-      id-token: write # Required for authentication using OIDC
+  check_release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check release validity
         run: sh .github/scripts/check-release.sh
-      - name: Publish
-        uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+
+  publishing:
+    needs: check_release
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
# Pull Request

## Related issue

Error running publishing job: https://github.com/meilisearch/meilisearch-dart/actions/runs/14748878787

> [Error](https://github.com/meilisearch/meilisearch-dart/actions/runs/14748878787/workflow)
> reusable workflows should be referenced at the top-level `jobs.*.uses' key, not within steps

## What does this PR do?
- Reference the workflow at the `job.*.uses` key level
- Separate the "check release" in a different job

Thank you so much for contributing to Meilisearch!
