### PR TITLE
Implement `rankingScoreThreshold` as search query parameter

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -297,3 +297,4 @@ reset_separator_tokens_1: await client.index('articles').resetSeparatorTokens();
 get_non_separator_tokens_1: await client.index('articles').getNonSeparatorTokens();
 update_non_separator_tokens_1: "await client.index('articles').updateNonSeparatorTokens([\"@\", \"#\"]);"
 reset_non_separator_tokens_1: await client.index('articles').resetNonSeparatorTokens();
+ranking_score_threshold: "await client\n    .index('movies')\n    .search('winter feast', SearchQuery(rankingScoreThreshold: 0.9));"

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -297,4 +297,4 @@ reset_separator_tokens_1: await client.index('articles').resetSeparatorTokens();
 get_non_separator_tokens_1: await client.index('articles').getNonSeparatorTokens();
 update_non_separator_tokens_1: "await client.index('articles').updateNonSeparatorTokens([\"@\", \"#\"]);"
 reset_non_separator_tokens_1: await client.index('articles').resetNonSeparatorTokens();
-ranking_score_threshold: "await client\n    .index('movies')\n    .search('winter feast', SearchQuery(rankingScoreThreshold: 0.9));"
+ranking_score_threshold: "await client\n    .index('INDEX_NAME')\n    .search('badman', SearchQuery(rankingScoreThreshold: 0.2));"

--- a/lib/src/query_parameters/index_search_query.dart
+++ b/lib/src/query_parameters/index_search_query.dart
@@ -34,6 +34,7 @@ class IndexSearchQuery extends SearchQuery {
     super.showRankingScore,
     super.vector,
     super.showRankingScoreDetails,
+    super.rankingScoreThreshold,
   });
 
   @override
@@ -71,6 +72,7 @@ class IndexSearchQuery extends SearchQuery {
     bool? showRankingScore,
     List<dynamic /* double | List<double> */ >? vector,
     bool? showRankingScoreDetails,
+    double? rankingScoreThreshold,
   }) =>
       IndexSearchQuery(
         query: query ?? this.query,
@@ -99,5 +101,7 @@ class IndexSearchQuery extends SearchQuery {
         vector: vector ?? this.vector,
         showRankingScoreDetails:
             showRankingScoreDetails ?? this.showRankingScoreDetails,
+        rankingScoreThreshold:
+            rankingScoreThreshold ?? this.rankingScoreThreshold,
       );
 }

--- a/lib/src/query_parameters/search_query.dart
+++ b/lib/src/query_parameters/search_query.dart
@@ -27,6 +27,8 @@ class SearchQuery extends Queryable {
   final bool? showRankingScore;
   @RequiredMeiliServerVersion('1.3.0')
   final bool? showRankingScoreDetails;
+  @RequiredMeiliServerVersion('1.9.0')
+  final double? rankingScoreThreshold;
   @RequiredMeiliServerVersion('1.3.0')
   final List<dynamic /* double | List<double> */ >? vector;
 
@@ -52,6 +54,7 @@ class SearchQuery extends Queryable {
     this.hybrid,
     this.showRankingScore,
     this.showRankingScoreDetails,
+    this.rankingScoreThreshold,
     this.vector,
   });
 
@@ -78,6 +81,7 @@ class SearchQuery extends Queryable {
       'hybrid': hybrid?.toMap(),
       'showRankingScore': showRankingScore,
       'showRankingScoreDetails': showRankingScoreDetails,
+      'rankingScoreThreshold': rankingScoreThreshold,
       'vector': vector,
     };
   }
@@ -105,6 +109,7 @@ class SearchQuery extends Queryable {
     bool? showRankingScore,
     List<dynamic>? vector,
     bool? showRankingScoreDetails,
+    double? rankingScoreThreshold,
   }) =>
       SearchQuery(
         offset: offset ?? this.offset,
@@ -131,5 +136,7 @@ class SearchQuery extends Queryable {
         vector: vector ?? this.vector,
         showRankingScoreDetails:
             showRankingScoreDetails ?? this.showRankingScoreDetails,
+        rankingScoreThreshold:
+            rankingScoreThreshold ?? this.rankingScoreThreshold,
       );
 }

--- a/test/code_samples.dart
+++ b/test/code_samples.dart
@@ -874,6 +874,11 @@ void main() {
       // #docregion getting_started_search
       await client.index('movies').search('botman');
       // #enddocregion
+      // #docregion ranking_score_threshold
+      await client
+          .index('movies')
+          .search('winter feast', SearchQuery(rankingScoreThreshold: 0.9));
+      // #enddocregion
     });
 
     // skip this test, since it's only used for generating code samples

--- a/test/code_samples.dart
+++ b/test/code_samples.dart
@@ -876,8 +876,8 @@ void main() {
       // #enddocregion
       // #docregion ranking_score_threshold
       await client
-          .index('movies')
-          .search('winter feast', SearchQuery(rankingScoreThreshold: 0.9));
+          .index('INDEX_NAME')
+          .search('badman', SearchQuery(rankingScoreThreshold: 0.2));
       // #enddocregion
     });
 

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -447,6 +447,32 @@ void main() {
           });
         });
       });
+
+      test('use rankingScoreThreshold', () async {
+        final res = await index
+            .search(
+              'The',
+              SearchQuery(
+                showRankingScore: true,
+                rankingScoreThreshold: 0.9,
+              ),
+            )
+            .asSearchResult()
+            .mapToContainer();
+
+        expect(res.hits.length, 3);
+
+        expect(
+          res.hits,
+          everyElement(
+            isA<MeiliDocumentContainer<Map<String, dynamic>>>().having(
+              (p0) => p0.rankingScore,
+              'rankingScore',
+              greaterThanOrEqualTo(0.9),
+            ),
+          ),
+        );
+      });
     });
 
     group('Nested Books', () {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #386

## What does this PR do?
- implemented rankingScoreThreshold search parameter

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering search results by a ranking score threshold parameter.
* **Tests**
  * Added a test verifying results respect the configured ranking score threshold.
* **Documentation**
  * Added code samples demonstrating how to use the ranking score threshold in search queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->