### PR TITLE
Make index swap test more permissive

### DIFF
--- a/test/swaps_test.dart
+++ b/test/swaps_test.dart
@@ -31,10 +31,10 @@ void main() {
       expect(response.type, 'indexSwap');
       expect(response.error, null);
       expect(response.status, 'succeeded');
-      expect(response.details!['swaps'], [
-        {'indexes': books},
-        {'indexes': movies}
-      ]);
+      var responseSwaps = response.details!['swaps'] as List;
+      expect(responseSwaps, hasLength(2));
+      expect(responseSwaps[0]['indexes'], books);
+      expect(responseSwaps[1]['indexes'], movies);
     });
   });
 


### PR DESCRIPTION
Fix [Meilisearch 1.18 tests run](https://github.com/meilisearch/meilisearch/actions/runs/17061126416/job/48368042156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation for swap-related responses by replacing broad deep-equality checks with targeted, element-wise assertions.
  * Added explicit length verification to ensure the expected number of items is returned.
  * Reduced brittleness by focusing on key fields rather than entire structures, making tests more resilient to non-essential changes.
  * Improved failure diagnostics to make issues easier to identify and resolve during test runs.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->