### PR TITLE
Add ID as a parameter for GetDocuments

### DIFF
--- a/lib/src/query_parameters/documents_query.dart
+++ b/lib/src/query_parameters/documents_query.dart
@@ -8,7 +8,7 @@ class DocumentsQuery extends Queryable {
   final List<String> fields;
 
   @RequiredMeiliServerVersion('1.14.0')
-  final List<int> ids;
+  final List<Object> ids;
 
   @RequiredMeiliServerVersion('1.2.0')
   final Object? filter;

--- a/test/documents_test.dart
+++ b/test/documents_test.dart
@@ -357,12 +357,10 @@ void main() {
           );
 
           expect(docs.total, equals(2));
-
           expect(docs.limit, greaterThan(0));
-          expect(docs.results[0][kbookId], booksForTest[0][kbookId]);
-          expect(docs.results[0][ktitle], booksForTest[0][ktitle]);
-          expect(docs.results[1][kbookId], booksForTest[1][kbookId]);
-          expect(docs.results[1][ktitle], booksForTest[1][ktitle]);
+          const itemEq = MapEquality<String, Object?>();
+          final listEq = UnorderedIterableEquality(itemEq);
+          expect(listEq.equals(docs.results, booksForTest), isTrue);
         });
 
         test('document with fields', () async {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #422 

## What does this PR do?
- This PR adds ids as a parameter in the getDocuments function and adds supporting tests for the new parameter.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documents can now be fetched by providing a list of IDs, enabling precise retrieval of specific documents (requires MeiliServer 1.14.0 or later).

* **Tests**
  * Added tests to validate retrieval behavior, totals, limits, and returned document IDs/titles when querying by ID list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->