### PR TITLE
Add support for showPerformanceDetails in search endpoints

### DIFF
--- a/lib/src/query_parameters/index_search_query.dart
+++ b/lib/src/query_parameters/index_search_query.dart
@@ -35,6 +35,7 @@ class IndexSearchQuery extends SearchQuery {
     super.vector,
     super.showRankingScoreDetails,
     super.rankingScoreThreshold,
+    super.showPerformanceDetails,
   });
 
   @override
@@ -73,6 +74,7 @@ class IndexSearchQuery extends SearchQuery {
     List<dynamic /* double | List<double> */ >? vector,
     bool? showRankingScoreDetails,
     double? rankingScoreThreshold,
+    bool? showPerformanceDetails,
   }) =>
       IndexSearchQuery(
         query: query ?? this.query,
@@ -103,5 +105,7 @@ class IndexSearchQuery extends SearchQuery {
             showRankingScoreDetails ?? this.showRankingScoreDetails,
         rankingScoreThreshold:
             rankingScoreThreshold ?? this.rankingScoreThreshold,
+        showPerformanceDetails:
+            showPerformanceDetails ?? this.showPerformanceDetails,
       );
 }

--- a/lib/src/query_parameters/search_query.dart
+++ b/lib/src/query_parameters/search_query.dart
@@ -31,6 +31,8 @@ class SearchQuery extends Queryable {
   final double? rankingScoreThreshold;
   @RequiredMeiliServerVersion('1.3.0')
   final List<dynamic /* double | List<double> */ >? vector;
+  @RequiredMeiliServerVersion('1.35.0')
+  final bool? showPerformanceDetails;
 
   const SearchQuery({
     this.offset,
@@ -56,6 +58,7 @@ class SearchQuery extends Queryable {
     this.showRankingScoreDetails,
     this.rankingScoreThreshold,
     this.vector,
+    this.showPerformanceDetails,
   });
 
   @override
@@ -83,6 +86,7 @@ class SearchQuery extends Queryable {
       'showRankingScoreDetails': showRankingScoreDetails,
       'rankingScoreThreshold': rankingScoreThreshold,
       'vector': vector,
+      'showPerformanceDetails': showPerformanceDetails,
     };
   }
 
@@ -110,6 +114,7 @@ class SearchQuery extends Queryable {
     List<dynamic>? vector,
     bool? showRankingScoreDetails,
     double? rankingScoreThreshold,
+    bool? showPerformanceDetails,
   }) =>
       SearchQuery(
         offset: offset ?? this.offset,
@@ -138,5 +143,7 @@ class SearchQuery extends Queryable {
             showRankingScoreDetails ?? this.showRankingScoreDetails,
         rankingScoreThreshold:
             rankingScoreThreshold ?? this.rankingScoreThreshold,
+        showPerformanceDetails:
+            showPerformanceDetails ?? this.showPerformanceDetails,
       );
 }

--- a/lib/src/results/paginated_search_result.dart
+++ b/lib/src/results/paginated_search_result.dart
@@ -10,6 +10,7 @@ class PaginatedSearchResult<T> extends Searcheable<T> {
     required super.query,
     required super.facetStats,
     required super.vector,
+    required super.performanceDetails,
     required this.hitsPerPage,
     required this.page,
     required this.totalHits,
@@ -45,6 +46,7 @@ class PaginatedSearchResult<T> extends Searcheable<T> {
       facetStats: _readFacetStats(map),
       indexUid: indexUid ?? _readIndexUid(map),
       vector: map['vector'] as List?,
+      performanceDetails: _readPerformanceDetails(map),
     );
   }
 
@@ -65,6 +67,7 @@ class PaginatedSearchResult<T> extends Searcheable<T> {
       query: query,
       totalHits: totalHits,
       totalPages: totalPages,
+      performanceDetails: performanceDetails,
     );
   }
 }

--- a/lib/src/results/search_result.dart
+++ b/lib/src/results/search_result.dart
@@ -11,6 +11,7 @@ class SearchResult<T> extends Searcheable<T> {
     required super.query,
     required super.facetStats,
     required super.vector,
+    required super.performanceDetails,
     required this.offset,
     required this.limit,
     required this.estimatedTotalHits,
@@ -41,6 +42,7 @@ class SearchResult<T> extends Searcheable<T> {
       facetDistribution: _readFacetDistribution(map),
       indexUid: indexUid ?? _readIndexUid(map),
       facetStats: _readFacetStats(map),
+      performanceDetails: _readPerformanceDetails(map),
     );
   }
 
@@ -60,5 +62,6 @@ class SearchResult<T> extends Searcheable<T> {
         offset: offset,
         processingTimeMs: processingTimeMs,
         query: query,
+        performanceDetails: performanceDetails,
       );
 }

--- a/lib/src/results/searchable.dart
+++ b/lib/src/results/searchable.dart
@@ -30,6 +30,9 @@ abstract class Searcheable<T> {
   final int? processingTimeMs;
   final List<dynamic /*double | List<double>*/ >? vector;
 
+  /// Performance details of the query, available when `showPerformanceDetails` is set to `true`.
+  final Map<String, dynamic>? performanceDetails;
+
   const Searcheable({
     required this.src,
     required this.indexUid,
@@ -39,6 +42,7 @@ abstract class Searcheable<T> {
     required this.processingTimeMs,
     required this.facetStats,
     required this.vector,
+    required this.performanceDetails,
   });
 
   static Searcheable<Map<String, dynamic>> createSearchResult(

--- a/lib/src/results/searchable_helpers.dart
+++ b/lib/src/results/searchable_helpers.dart
@@ -22,6 +22,9 @@ Map<String, FacetStat>? _readFacetStats(
   );
 }
 
+Map<String, dynamic>? _readPerformanceDetails(Map<String, Object?> map) =>
+    (map['performanceDetails'] as Map<String, dynamic>?);
+
 Map<String, Map<String, int>>? _readFacetDistribution(
   Map<String, Object?> map,
 ) {

--- a/test/multi_index_search_test.dart
+++ b/test/multi_index_search_test.dart
@@ -45,6 +45,53 @@ void main() {
       expect(result.results.last.indexUid, index2.uid);
       expect(result.results.last.hits.length, 2);
     });
+
+    test("Multi search with showPerformanceDetails", () async {
+      final result = await client.multiSearch(MultiSearchQuery(queries: [
+        IndexSearchQuery(
+          query: "prince",
+          indexUid: index1.uid,
+          showPerformanceDetails: true,
+        ),
+        IndexSearchQuery(
+          query: "hobbit",
+          indexUid: index2.uid,
+          showPerformanceDetails: true,
+        ),
+      ]));
+
+      expect(result.results, hasLength(2));
+      expect(result.results.first.performanceDetails, isNotNull);
+      expect(
+          result.results.first.performanceDetails, isA<Map<String, dynamic>>());
+      expect(result.results.last.performanceDetails, isNotNull);
+      expect(
+          result.results.last.performanceDetails, isA<Map<String, dynamic>>());
+    });
+
+    test("Multi search performanceDetails is null when not requested",
+        () async {
+      final result = await client.multiSearch(MultiSearchQuery(queries: [
+        IndexSearchQuery(
+          query: "prince",
+          indexUid: index1.uid,
+        ),
+      ]));
+
+      expect(result.results.first.performanceDetails, isNull);
+    });
+
+    test("Multi search performanceDetails is null when set to false", () async {
+      final result = await client.multiSearch(MultiSearchQuery(queries: [
+        IndexSearchQuery(
+          query: "prince",
+          indexUid: index1.uid,
+          showPerformanceDetails: false,
+        ),
+      ]));
+
+      expect(result.results.first.performanceDetails, isNull);
+    });
   });
 
   test('code samples', () async {

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -148,6 +148,32 @@ void main() {
         );
       });
 
+      test('Show performance details', () async {
+        final result = await index.search(
+          'prince',
+          SearchQuery(showPerformanceDetails: true),
+        );
+
+        expect(result.performanceDetails, isNotNull);
+        expect(result.performanceDetails, isA<Map<String, dynamic>>());
+        expect(result.performanceDetails, isNotEmpty);
+      });
+
+      test('performanceDetails is null when not requested', () async {
+        final result = await index.search('prince');
+
+        expect(result.performanceDetails, isNull);
+      });
+
+      test('performanceDetails is null when set to false', () async {
+        final result = await index.search(
+          'prince',
+          SearchQuery(showPerformanceDetails: false),
+        );
+
+        expect(result.performanceDetails, isNull);
+      });
+
       group('with', () {
         test('offset parameter', () async {
           final result =


### PR DESCRIPTION
# Pull Request
Add support for `showPerformanceDetails`

## Related issue
Resolves #466

## What does this PR do?
- Add `showPerformanceDetails` request parameter to `SearchQuery` and `IndexSearchQuery`
- Add `performanceDetails` response field to `Searcheable`, `SearchResult`, and `PaginatedSearchResult` as raw `Map<String, dynamic>?`
- Applies to search and multi-search endpoints
- Add test cases

Tested with this code: 
```dart
import 'package:meilisearch/meilisearch.dart';

void main() async {
  var client = MeiliSearchClient('http://localhost:7700', 'aSampleMasterKey');
  final index = client.index('movies');

  final searchResult = await index.search(
    'Taisto Kasurinen',
    SearchQuery(showPerformanceDetails: true),
  );

  final multiSearchResult = await client.multiSearch(
    MultiSearchQuery(
      queries: [
        IndexSearchQuery(
          query: 'Taisto Kasurinen',
          indexUid: index.uid,
          showPerformanceDetails: true,
        ),
      ],
    ),
  );

  print(searchResult.performanceDetails);
  print(multiSearchResult.results.first.performanceDetails);
}
```

Result: 
```
{wait for permit: 45.38µs, search > tokenize: 102.29µs, search > resolve universe: 379.29µs, search > keyword search: 39.04µs, search > format: 38.13µs, search: 789.34µs}
{wait for permit: 50.71µs, search > tokenize: 86.67µs, search > resolve universe: 459.13µs, search > keyword search: 41.21µs, search > format: 38.54µs, search: 846.04µs}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional flag to request performance details with searches (requires Meilisearch 1.35.0+). When enabled, search results include a performanceDetails map propagated through paginated and mapped results.

* **Tests**
  * Added tests covering presence/absence of performanceDetails for single and multi-index searches, including true/false/default cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->