### PR TITLE
Add federation and weight support to multiSearch

### DIFF
--- a/lib/src/query_parameters/_exports.dart
+++ b/lib/src/query_parameters/_exports.dart
@@ -13,3 +13,5 @@ export 'facet_search_query.dart';
 export 'swap_index.dart';
 export 'hybrid_search.dart';
 export 'export_query.dart';
+export 'federation.dart';
+export 'federation_options.dart';

--- a/lib/src/query_parameters/federation.dart
+++ b/lib/src/query_parameters/federation.dart
@@ -1,0 +1,36 @@
+import '../annotations.dart';
+
+/// Top-level federation configuration for multi-search.
+///
+/// When present in a [MultiSearchQuery], Meilisearch returns a single,
+/// merged list of results ordered by descending ranking score.
+@RequiredMeiliServerVersion('1.10.0')
+class Federation {
+  /// Number of results to skip in the merged list.
+  final int? offset;
+
+  /// Maximum number of results to return in the merged list.
+  final int? limit;
+
+  /// Request facet distributions per index.
+  /// Keys are index UIDs, values are lists of attribute names.
+  final Map<String, List<String>>? facetsByIndex;
+
+  /// When true, facet information from all queried indexes is merged
+  /// into a single object in the response.
+  final bool? mergeFacets;
+
+  const Federation({
+    this.offset,
+    this.limit,
+    this.facetsByIndex,
+    this.mergeFacets,
+  });
+
+  Map<String, Object?> toMap() => {
+        if (offset != null) 'offset': offset,
+        if (limit != null) 'limit': limit,
+        if (facetsByIndex != null) 'facetsByIndex': facetsByIndex,
+        if (mergeFacets != null) 'mergeFacets': mergeFacets,
+      };
+}

--- a/lib/src/query_parameters/federation_options.dart
+++ b/lib/src/query_parameters/federation_options.dart
@@ -1,0 +1,30 @@
+import '../annotations.dart';
+
+/// Per-query federation options for multi-search.
+///
+/// Used within [IndexSearchQuery] to control how a specific query
+/// participates in a federated search.
+@RequiredMeiliServerVersion('1.10.0')
+class FederationOptions {
+  /// A multiplicative factor for ranking scores of search results
+  /// in this specific query.
+  ///
+  /// If < 1.0, hits from this query are less likely to appear in
+  /// the final results. If > 1.0, they are more likely.
+  /// Must be a positive floating-point number. Defaults to 1.0.
+  final double? weight;
+
+  /// Indicates the remote instance where Meilisearch will perform the query.
+  /// Must correspond to a configured remote object.
+  final String? remote;
+
+  const FederationOptions({
+    this.weight,
+    this.remote,
+  });
+
+  Map<String, Object?> toMap() => {
+        if (weight != null) 'weight': weight,
+        if (remote != null) 'remote': remote,
+      };
+}

--- a/lib/src/query_parameters/index_search_query.dart
+++ b/lib/src/query_parameters/index_search_query.dart
@@ -1,6 +1,7 @@
 import '../annotations.dart';
 import '../filter_builder/_exports.dart';
 import '../results/matching_strategy_enum.dart';
+import 'federation_options.dart';
 import 'hybrid_search.dart';
 import 'search_query.dart';
 
@@ -9,9 +10,14 @@ class IndexSearchQuery extends SearchQuery {
   final String indexUid;
   final String? query;
 
+  /// Per-query options for federated search (e.g. weight).
+  @RequiredMeiliServerVersion('1.10.0')
+  final FederationOptions? federationOptions;
+
   const IndexSearchQuery({
     required this.indexUid,
     this.query,
+    this.federationOptions,
     super.offset,
     super.limit,
     super.page,
@@ -42,6 +48,7 @@ class IndexSearchQuery extends SearchQuery {
     return {
       'indexUid': indexUid,
       'q': query,
+      'federationOptions': federationOptions?.toMap(),
       ...super.buildMap(),
     };
   }
@@ -50,6 +57,7 @@ class IndexSearchQuery extends SearchQuery {
   IndexSearchQuery copyWith({
     String? indexUid,
     String? query,
+    FederationOptions? federationOptions,
     int? offset,
     int? limit,
     int? page,
@@ -77,6 +85,7 @@ class IndexSearchQuery extends SearchQuery {
       IndexSearchQuery(
         query: query ?? this.query,
         indexUid: indexUid ?? this.indexUid,
+        federationOptions: federationOptions ?? this.federationOptions,
         offset: offset ?? this.offset,
         limit: limit ?? this.limit,
         page: page ?? this.page,

--- a/lib/src/query_parameters/multi_search_query.dart
+++ b/lib/src/query_parameters/multi_search_query.dart
@@ -1,20 +1,31 @@
 import 'queryable.dart';
 
 import '../annotations.dart';
+import 'federation.dart';
 import 'index_search_query.dart';
 
 @RequiredMeiliServerVersion('1.1.0')
 class MultiSearchQuery extends Queryable {
   final List<IndexSearchQuery> queries;
 
+  /// When present, Meilisearch returns a single merged list of results
+  /// ordered by descending ranking score (federated search).
+  ///
+  /// Pass an empty [Federation] object (e.g. `Federation()`) to enable
+  /// federated search with default settings.
+  @RequiredMeiliServerVersion('1.10.0')
+  final Federation? federation;
+
   const MultiSearchQuery({
     required this.queries,
+    this.federation,
   });
 
   @override
   Map<String, Object?> buildMap() {
     return {
       'queries': queries.map((e) => e.toSparseMap()).toList(),
+      if (federation != null) 'federation': federation!.toMap(),
     };
   }
 }

--- a/lib/src/results/_exports.dart
+++ b/lib/src/results/_exports.dart
@@ -1,4 +1,5 @@
 export 'multi_search_result.dart';
+export 'federated_search_result.dart';
 export 'searchable.dart';
 export 'tasks_results.dart';
 export 'result.dart';

--- a/lib/src/results/federated_search_result.dart
+++ b/lib/src/results/federated_search_result.dart
@@ -1,0 +1,114 @@
+import 'facet_stat.dart';
+
+/// Represents the result of a federated multi-search.
+///
+/// When [Federation] is passed to [MultiSearchQuery], Meilisearch returns
+/// a single merged list of hits instead of per-query result objects.
+/// Each hit includes a `_federation` map with `indexUid` and `queriesPosition`.
+class FederatedSearchResult {
+  /// Merged list of hits from all queried indexes.
+  ///
+  /// Each hit contains a `_federation` key with `indexUid` (the source index)
+  /// and `queriesPosition` (the index of the originating query).
+  final List<Map<String, dynamic>> hits;
+
+  /// Processing time in milliseconds.
+  final int? processingTimeMs;
+
+  /// Number of results to skip.
+  final int? offset;
+
+  /// Maximum number of results returned.
+  final int? limit;
+
+  /// Estimated total number of hits across all queries.
+  final int? estimatedTotalHits;
+
+  /// Number of hits from semantic search.
+  final int? semanticHitCount;
+
+  /// Per-index facet distributions (when `facetsByIndex` is used).
+  final Map<String, Map<String, Map<String, int>>>? facetsByIndex;
+
+  /// Merged facet distribution (when `mergeFacets` is true).
+  final Map<String, Map<String, int>>? facetDistribution;
+
+  /// Merged facet stats (when `mergeFacets` is true).
+  final Map<String, FacetStat>? facetStats;
+
+  const FederatedSearchResult({
+    required this.hits,
+    this.processingTimeMs,
+    this.offset,
+    this.limit,
+    this.estimatedTotalHits,
+    this.semanticHitCount,
+    this.facetsByIndex,
+    this.facetDistribution,
+    this.facetStats,
+  });
+
+  factory FederatedSearchResult.fromMap(Map<String, Object?> map) {
+    return FederatedSearchResult(
+      hits: (map['hits'] as List?)?.cast<Map<String, dynamic>>() ?? const [],
+      processingTimeMs: map['processingTimeMs'] as int?,
+      offset: map['offset'] as int?,
+      limit: map['limit'] as int?,
+      estimatedTotalHits: map['estimatedTotalHits'] as int?,
+      semanticHitCount: map['semanticHitCount'] as int?,
+      facetsByIndex: _readFacetsByIndex(map),
+      facetDistribution: _readFacetDistribution(map),
+      facetStats: _readFacetStats(map),
+    );
+  }
+
+  static Map<String, Map<String, Map<String, int>>>? _readFacetsByIndex(
+    Map<String, Object?> map,
+  ) {
+    final raw = map['facetsByIndex'] as Map<String, Object?>?;
+    if (raw == null) return null;
+
+    return raw.map(
+      (indexUid, indexFacets) {
+        final facetMap = (indexFacets as Map<String, Object?>);
+        final distribution =
+            (facetMap['distribution'] as Map<String, Object?>?)?.map(
+                  (key, value) => MapEntry(
+                    key,
+                    (value as Map<String, Object?>).cast<String, int>(),
+                  ),
+                ) ??
+                {};
+        return MapEntry(indexUid, distribution);
+      },
+    );
+  }
+
+  static Map<String, Map<String, int>>? _readFacetDistribution(
+    Map<String, Object?> map,
+  ) {
+    final src = map['facetDistribution'];
+    if (src == null) return null;
+
+    return (src as Map<String, Object?>).map(
+      (key, value) => MapEntry(
+        key,
+        (value as Map<String, Object?>).cast<String, int>(),
+      ),
+    );
+  }
+
+  static Map<String, FacetStat>? _readFacetStats(
+    Map<String, Object?> map,
+  ) {
+    final raw = map['facetStats'] as Map<String, Object?>?;
+    if (raw == null) return null;
+
+    return raw.map(
+      (key, value) => MapEntry(
+        key,
+        FacetStat.fromMap(value as Map<String, Object?>),
+      ),
+    );
+  }
+}

--- a/lib/src/results/multi_search_result.dart
+++ b/lib/src/results/multi_search_result.dart
@@ -1,18 +1,34 @@
+import 'federated_search_result.dart';
 import 'searchable.dart';
 
 class MultiSearchResult {
-  final List<Searcheable<Map<String, Object?>>> results;
+  /// Per-query results (non-federated multi-search).
+  /// This is `null` when federation is used.
+  final List<Searcheable<Map<String, Object?>>>? results;
+
+  /// Merged federated result (federated multi-search).
+  /// This is `null` when federation is not used.
+  final FederatedSearchResult? federated;
 
   const MultiSearchResult({
-    required this.results,
+    this.results,
+    this.federated,
   });
 
   factory MultiSearchResult.fromMap(Map<String, Object?> json) {
-    final list = json['results'] as List<Object?>;
-    final parsed = list
-        .cast<Map<String, Object?>>()
-        .map((e) => Searcheable.createSearchResult(e));
+    // When federation is used, the response has 'hits' at the top level
+    // instead of 'results'.
+    if (json.containsKey('results')) {
+      final list = json['results'] as List<Object?>;
+      final parsed = list
+          .cast<Map<String, Object?>>()
+          .map((e) => Searcheable.createSearchResult(e));
 
-    return MultiSearchResult(results: parsed.toList());
+      return MultiSearchResult(results: parsed.toList());
+    } else {
+      return MultiSearchResult(
+        federated: FederatedSearchResult.fromMap(json),
+      );
+    }
   }
 }

--- a/test/multi_index_search_test.dart
+++ b/test/multi_index_search_test.dart
@@ -39,11 +39,124 @@ void main() {
 
       expect(result.results, hasLength(2));
       //test first result
-      expect(result.results.first.indexUid, index1.uid);
-      expect(result.results.first.hits.length, 1);
+      expect(result.results!.first.indexUid, index1.uid);
+      expect(result.results!.first.hits.length, 1);
       //test second result
-      expect(result.results.last.indexUid, index2.uid);
-      expect(result.results.last.hits.length, 2);
+      expect(result.results!.last.indexUid, index2.uid);
+      expect(result.results!.last.hits.length, 2);
+    });
+  });
+
+  group("Federated search", () {
+    setUpClient();
+    late MeiliSearchIndex index1;
+    late MeiliSearchIndex index2;
+
+    setUp(() async {
+      index1 = client.index(randomUid());
+      index2 = client.index(randomUid());
+
+      await Future.wait([
+        index1.updateFilterableAttributes([ktag]).waitFor(client: client),
+        index2.updateFilterableAttributes([ktag]).waitFor(client: client),
+        index1.addDocuments(books).waitFor(client: client),
+        index2.addDocuments(books).waitFor(client: client),
+      ]);
+    });
+
+    test("Federated search with empty federation object", () async {
+      final result = await client.multiSearch(MultiSearchQuery(
+        federation: Federation(),
+        queries: [
+          IndexSearchQuery(
+            query: "Prince",
+            indexUid: index1.uid,
+          ),
+          IndexSearchQuery(
+            query: "Prince",
+            indexUid: index2.uid,
+          ),
+        ],
+      ));
+
+      expect(result.federated, isNotNull);
+      expect(result.results, isNull);
+
+      final federated = result.federated!;
+      expect(federated.hits, isNotEmpty);
+      // Each hit should have _federation metadata
+      for (final hit in federated.hits) {
+        expect(hit['_federation'], isNotNull);
+        final federation = hit['_federation'] as Map<String, dynamic>;
+        expect(federation['indexUid'], isNotNull);
+        expect(federation['queriesPosition'], isNotNull);
+      }
+    });
+
+    test("Federated search with weight", () async {
+      final result = await client.multiSearch(MultiSearchQuery(
+        federation: Federation(),
+        queries: [
+          IndexSearchQuery(
+            query: "Prince",
+            indexUid: index1.uid,
+            federationOptions: FederationOptions(weight: 0.1),
+          ),
+          IndexSearchQuery(
+            query: "Prince",
+            indexUid: index2.uid,
+            federationOptions: FederationOptions(weight: 10.0),
+          ),
+        ],
+      ));
+
+      expect(result.federated, isNotNull);
+      final federated = result.federated!;
+      expect(federated.hits, isNotEmpty);
+
+      // With a much higher weight on index2, its results should
+      // appear before index1's results.
+      final firstHit = federated.hits.first;
+      final firstFederation = firstHit['_federation'] as Map<String, dynamic>;
+      expect(firstFederation['indexUid'], index2.uid);
+    });
+
+    test("Federated search with limit and offset", () async {
+      final result = await client.multiSearch(MultiSearchQuery(
+        federation: Federation(limit: 2, offset: 0),
+        queries: [
+          IndexSearchQuery(
+            query: "",
+            indexUid: index1.uid,
+          ),
+          IndexSearchQuery(
+            query: "",
+            indexUid: index2.uid,
+          ),
+        ],
+      ));
+
+      expect(result.federated, isNotNull);
+      final federated = result.federated!;
+      expect(federated.hits.length, lessThanOrEqualTo(2));
+      expect(federated.limit, 2);
+      expect(federated.offset, 0);
+      expect(federated.estimatedTotalHits, isNotNull);
+    });
+
+    test("Federated search result has processingTimeMs", () async {
+      final result = await client.multiSearch(MultiSearchQuery(
+        federation: Federation(),
+        queries: [
+          IndexSearchQuery(
+            query: "Hobbit",
+            indexUid: index1.uid,
+          ),
+        ],
+      ));
+
+      expect(result.federated, isNotNull);
+      expect(result.federated!.processingTimeMs, isNotNull);
     });
   });
 
@@ -54,6 +167,34 @@ void main() {
       IndexSearchQuery(query: 'nemo', indexUid: 'movies', limit: 5),
       IndexSearchQuery(query: 'us', indexUid: 'movies_ratings'),
     ]));
+    // #enddocregion
+  }, skip: true);
+
+  test('code samples federated', () async {
+    // #docregion federated_multi_search_1
+    await client.multiSearch(MultiSearchQuery(
+      federation: Federation(),
+      queries: [
+        IndexSearchQuery(query: 'batman', indexUid: 'movies'),
+        IndexSearchQuery(query: 'batman', indexUid: 'comics'),
+      ],
+    ));
+    // #enddocregion
+  }, skip: true);
+
+  test('code samples federated with weight', () async {
+    // #docregion federated_multi_search_weight
+    await client.multiSearch(MultiSearchQuery(
+      federation: Federation(),
+      queries: [
+        IndexSearchQuery(query: 'batman', indexUid: 'movies'),
+        IndexSearchQuery(
+          query: 'batman',
+          indexUid: 'comics',
+          federationOptions: FederationOptions(weight: 1.2),
+        ),
+      ],
+    ));
     // #enddocregion
   }, skip: true);
 }


### PR DESCRIPTION
## Summary
- Adds `federation` parameter to `MultiSearchQuery` for federated multi-search (merged result list)
- Adds `federationOptions` with `weight` to `IndexSearchQuery` for per-query ranking boost
- Adds `FederatedSearchResult` to handle the federated response format
- Adds integration tests for federated search

Closes #390

## Changes

### New classes
- **`Federation`** — top-level federation config (`limit`, `offset`, `facetsByIndex`, `mergeFacets`)
- **`FederationOptions`** — per-query options (`weight`, `remote`)
- **`FederatedSearchResult`** — result type for federated responses (single merged `hits` list with `_federation` metadata)

### Modified classes
- **`MultiSearchQuery`** — new optional `federation` field
- **`IndexSearchQuery`** — new optional `federationOptions` field (+ `copyWith`)
- **`MultiSearchResult`** — handles both response formats: `results` (non-federated) or `federated` (federated)

### Usage

```dart
// Basic federated search
final result = await client.multiSearch(MultiSearchQuery(
  federation: Federation(),
  queries: [
    IndexSearchQuery(query: 'batman', indexUid: 'movies'),
    IndexSearchQuery(query: 'batman', indexUid: 'comics'),
  ],
));
print(result.federated!.hits); // merged list

// With weight boosting
final result = await client.multiSearch(MultiSearchQuery(
  federation: Federation(limit: 10),
  queries: [
    IndexSearchQuery(query: 'batman', indexUid: 'movies'),
    IndexSearchQuery(
      query: 'batman',
      indexUid: 'comics',
      federationOptions: FederationOptions(weight: 1.5),
    ),
  ],
));
```

## Test plan
- [x] Federated search with empty federation object
- [x] Federated search with weight (verifies ranking boost)
- [x] Federated search with limit and offset
- [x] Federated search result has processingTimeMs
- [x] Existing multi-search tests still pass
- [x] `dart analyze` clean
- [x] `dart format` clean

## AI Disclosure
Claude was used to assist with the implementation, tests, and PR preparation. All code was reviewed and verified against the Meilisearch API documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced federated multi-search capabilities, enabling merged and ordered search results across multiple indexes with optional facet distribution merging
  * Added federation configuration options to customize offset, limit, and facet behavior per index
  * Added support for per-query federation options including weighted results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->