### PR TITLE
Update outdated documentation links

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -212,7 +212,7 @@ geosearch_guide_sort_settings_1: |-
 geosearch_guide_sort_usage_1: "await client.index('restaurants').search(\n    '', SearchQuery(sort: ['_geoPoint(48.8561446, 2.2978204):asc']));"
 geosearch_guide_sort_usage_2: "await client.index('restaurants').search(\n    '',\n    SearchQuery(\n        sort: ['_geoPoint(48.8561446, 2.2978204):asc', 'rating:desc']));"
 authorization_header_1: |-
-  var client = MeiliSearchClient('MEILISEARCH_URL', 'masterKey');
+  var client = MeiliSearchClient('MEILISEARCH_URL', 'MEILISEARCH_KEY');
   await client.getKeys();
 get_one_key_1: |-
   await client.getKey('6062abda-a5aa-4414-ac91-ecd7944c0f8d');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ No breaking change but addition of new features
 - Add `Map<String, dynamic> src` to `Searchable` which exposes the raw json object returned from the server.
   Just in case we don't keep up with new meilisearch releases, the user has a way to access new features.
 
-[experimental]* To adopt a experimental [change you must opt-in manually](https://www.meilisearch.com/docs/learn/experimental/overview#activating-experimental-features)
+[experimental]* To adopt a experimental [change you must opt-in manually](https://www.meilisearch.com/docs/learn/resources/experimental_features_overview#activating-experimental-features)
 
 # 0.14.0
 ### Breaking Changes:
@@ -363,7 +363,7 @@ This version makes this package compatible with Meilisearch v0.25.0 and newer
 ## Changes
 - Add method to responds with raw information from API `client.getRawIndex` (#124) @brunoocasali
 - Run a `pub upgrade` in dependencies (#128) @brunoocasali
-- Add support to keys (according to v0.25.0 spec) [more](https://www.meilisearch.com/docs/reference/api/keys#keys) (#121) @brunoocasali
+- Add support to keys (according to v0.25.0 spec) [more](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#keys) (#121) @brunoocasali
   - Create a new resource class `Key` to represent keys
   - Create methods to support keys:
     - `client.getKeys`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://discord.meilisearch.com">Discord</a> |
   <a href="https://roadmap.meilisearch.com/tabs/1-under-consideration">Roadmap</a> |
   <a href="https://www.meilisearch.com">Website</a> |
-  <a href="https://www.meilisearch.com/docs/faq">FAQ</a>
+  <a href="https://www.meilisearch.com/docs/learn/resources/faq">FAQ</a>
 </h4>
 
 <p align="center">
@@ -95,7 +95,7 @@ void main() async {
 }
 ```
 
-With the `uid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/learn/advanced/asynchronous_operations#task-status).
+With the `uid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/learn/async/asynchronous_operations#task-status).
 
 #### Basic Search <!-- omit in toc -->
 
@@ -120,7 +120,7 @@ JSON Output:
 
 #### Custom Search <!-- omit in toc -->
 
-All the supported options are described in the [search parameters](https://www.meilisearch.com/docs/reference/api/search#search-parameters) section of the documentation.
+All the supported options are described in the [search parameters](https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-parameters) section of the documentation.
 
 ```dart
 var result = await index.search(
@@ -161,7 +161,7 @@ await index.updateFilterableAttributes(['id', 'genres']);
 You only need to perform this operation once.
 
 Note that MeiliSearch will rebuild your index whenever you update `filterableAttributes`.
-Depending on the size of your dataset, this might take time. You can track the process using the [task status](https://www.meilisearch.com/docs/learn/advanced/asynchronous_operations#task-status).
+Depending on the size of your dataset, this might take time. You can track the process using the [task status](https://www.meilisearch.com/docs/learn/async/asynchronous_operations#task-status).
 
 Then, you can perform the search:
 
@@ -213,10 +213,10 @@ This package guarantees compatibility with [version v1.x of Meilisearch](https:/
 
 The following sections in our main documentation website may interest you:
 
-- **Manipulate documents**: see the [API references](https://www.meilisearch.com/docs/reference/api/documents) or read more about [documents](https://www.meilisearch.com/docs/learn/core_concepts/documents).
-- **Search**: see the [API references](https://www.meilisearch.com/docs/reference/api/search) or follow our guide on [search parameters](https://www.meilisearch.com/docs/reference/api/search#search-parameters).
-- **Manage the indexes**: see the [API references](https://www.meilisearch.com/docs/reference/api/indexes) or read more about [indexes](https://www.meilisearch.com/docs/learn/core_concepts/indexes).
-- **Configure the index settings**: see the [API references](https://www.meilisearch.com/docs/reference/api/settings) or follow our guide on [settings parameters](https://www.meilisearch.com/docs/learn/configuration/settings).
+- **Manipulate documents**: see the [API references](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get) or read more about [documents](https://www.meilisearch.com/docs/learn/getting_started/documents).
+- **Search**: see the [API references](https://www.meilisearch.com/docs/reference/api/search/search-with-post) or follow our guide on [search parameters](https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-parameters).
+- **Manage the indexes**: see the [API references](https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes) or read more about [indexes](https://www.meilisearch.com/docs/learn/getting_started/indexes).
+- **Configure the index settings**: see the [API references](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings) or follow our guide on [settings parameters](https://www.meilisearch.com/docs/learn/configuration/configuring_index_settings).
 
 ## ⚙️ Contributing
 

--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -164,7 +164,7 @@ class MeiliSearchIndex {
   /// *
   /// {@template meili.csv}
   /// The passed documents must be a valid CSV string, where the first line contains objects' keys and types, and each subsequent line corresponds to an object.
-  /// [see relevant documentation](https://www.meilisearch.com/docs/learn/core_concepts/documents#csv)
+  /// [see relevant documentation](https://www.meilisearch.com/docs/learn/getting_started/documents#csv)
   /// {@endtemplate}
   ///
   /// *

--- a/lib/src/settings/index_settings.dart
+++ b/lib/src/settings/index_settings.dart
@@ -39,7 +39,7 @@ class IndexSettings {
   /// List of tokens that will not be considered as word separators by Meilisearch.
   List<String>? nonSeparatorTokens;
 
-  /// Attributes to use in [filters](https://www.meilisearch.com/docs/reference/api/search#filter)
+  /// Attributes to use in [filters](https://www.meilisearch.com/docs/reference/api/search/search-with-post#filter)
   List<String>? filterableAttributes;
 
   /// Search returns documents with distinct (different) values of the given field


### PR DESCRIPTION
## Summary
- Updated `meilisearch.com/docs` links to match the current sitemap URLs
- Old paths were either redirecting (308) or returning 404s

## Test plan
- [ ] Verify all updated links resolve correctly (no 404s or extra redirects)
- [ ] No code logic changed — only documentation URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links throughout the project to align with the latest Meilisearch documentation structure.
  * Fixed references to API endpoints and feature documentation to point to current documentation URLs across README, CHANGELOG, and code documentation comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->