### PR TITLE
Add network API

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -306,4 +306,64 @@ class MeiliSearchClient {
     );
     return Task.fromMap(response.data!);
   }
+
+  /// Current network topology (requires experimental network feature).
+  @RequiredMeiliServerVersion('1.13.0')
+  Future<Network> getNetwork() async {
+    final response = await http.getMethod<Map<String, Object?>>('/network');
+    return Network.fromMap(response.data!);
+  }
+
+  /// Partially update network topology via `PATCH /network`.
+  @RequiredMeiliServerVersion('1.13.0')
+  Future<Network> updateNetwork(UpdateNetworkOptions input) async {
+    final data = input.toPatchMap();
+    if (data.isEmpty) {
+      throw ArgumentError.value(
+        input,
+        'input',
+        'input must contain at least one field',
+      );
+    }
+    final response =
+        await http.patchMethod<Map<String, Object?>>('/network', data: data);
+    return Network.fromMap(response.data!);
+  }
+
+  /// Register or replace a single remote by name.
+  @RequiredMeiliServerVersion('1.13.0')
+  Future<Network> addRemote(String remoteName, Remote remote) {
+    return updateNetwork(
+      UpdateNetworkOptions(remotes: {remoteName: remote}),
+    );
+  }
+
+  /// Remove a remote by setting its entry to `null` in the patch payload.
+  @RequiredMeiliServerVersion('1.13.0')
+  Future<Network> removeRemote(String remoteName) {
+    return updateNetwork(
+      UpdateNetworkOptions(remotes: {remoteName: null}),
+    );
+  }
+
+  @RequiredMeiliServerVersion('1.13.0')
+  Future<Network> addRemotesToShard(String shardName, List<String> remotes) {
+    return updateNetwork(
+      UpdateNetworkOptions(
+        shards: {shardName: Shard(addRemotes: remotes)},
+      ),
+    );
+  }
+
+  @RequiredMeiliServerVersion('1.13.0')
+  Future<Network> removeRemotesFromShard(
+    String shardName,
+    List<String> remotes,
+  ) {
+    return updateNetwork(
+      UpdateNetworkOptions(
+        shards: {shardName: Shard(removeRemotes: remotes)},
+      ),
+    );
+  }
 }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -366,18 +366,4 @@ class MeiliSearchClient {
       ),
     );
   }
-
-  /// Get the status of all experimental features that can be toggled at runtime
-  @RequiredMeiliServerVersion('1.3.0')
-  Future<ExperimentalFeatures> getExperimentalFeatures() async {
-    return http.getExperimentalFeatures();
-  }
-
-  /// Set the status of experimental features that can be toggled at runtime
-  @RequiredMeiliServerVersion('1.3.0')
-  Future<ExperimentalFeatures> updateExperimentalFeatures(
-    UpdateExperimentalFeatures input,
-  ) async {
-    return http.updateExperimentalFeatures(input);
-  }
 }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -366,4 +366,18 @@ class MeiliSearchClient {
       ),
     );
   }
+
+  /// Get the status of all experimental features that can be toggled at runtime
+  @RequiredMeiliServerVersion('1.3.0')
+  Future<ExperimentalFeatures> getExperimentalFeatures() async {
+    return http.getExperimentalFeatures();
+  }
+
+  /// Set the status of experimental features that can be toggled at runtime
+  @RequiredMeiliServerVersion('1.3.0')
+  Future<ExperimentalFeatures> updateExperimentalFeatures(
+    UpdateExperimentalFeatures input,
+  ) async {
+    return http.updateExperimentalFeatures(input);
+  }
 }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -308,14 +308,14 @@ class MeiliSearchClient {
   }
 
   /// Current network topology (requires experimental network feature).
-  @RequiredMeiliServerVersion('1.13.0')
+  @RequiredMeiliServerVersion('1.37.0')
   Future<Network> getNetwork() async {
     final response = await http.getMethod<Map<String, Object?>>('/network');
     return Network.fromMap(response.data!);
   }
 
   /// Partially update network topology via `PATCH /network`.
-  @RequiredMeiliServerVersion('1.13.0')
+  @RequiredMeiliServerVersion('1.37.0')
   Future<Network> updateNetwork(UpdateNetworkOptions input) async {
     final data = input.toPatchMap();
     if (data.isEmpty) {
@@ -331,7 +331,7 @@ class MeiliSearchClient {
   }
 
   /// Register or replace a single remote by name.
-  @RequiredMeiliServerVersion('1.13.0')
+  @RequiredMeiliServerVersion('1.37.0')
   Future<Network> addRemote(String remoteName, Remote remote) {
     return updateNetwork(
       UpdateNetworkOptions(remotes: {remoteName: remote}),
@@ -339,14 +339,14 @@ class MeiliSearchClient {
   }
 
   /// Remove a remote by setting its entry to `null` in the patch payload.
-  @RequiredMeiliServerVersion('1.13.0')
+  @RequiredMeiliServerVersion('1.37.0')
   Future<Network> removeRemote(String remoteName) {
     return updateNetwork(
       UpdateNetworkOptions(remotes: {remoteName: null}),
     );
   }
 
-  @RequiredMeiliServerVersion('1.13.0')
+  @RequiredMeiliServerVersion('1.37.0')
   Future<Network> addRemotesToShard(String shardName, List<String> remotes) {
     return updateNetwork(
       UpdateNetworkOptions(
@@ -355,7 +355,7 @@ class MeiliSearchClient {
     );
   }
 
-  @RequiredMeiliServerVersion('1.13.0')
+  @RequiredMeiliServerVersion('1.37.0')
   Future<Network> removeRemotesFromShard(
     String shardName,
     List<String> remotes,

--- a/lib/src/query_parameters/index_search_query.dart
+++ b/lib/src/query_parameters/index_search_query.dart
@@ -35,6 +35,7 @@ class IndexSearchQuery extends SearchQuery {
     super.vector,
     super.showRankingScoreDetails,
     super.rankingScoreThreshold,
+    super.useNetwork,
   });
 
   @override
@@ -73,6 +74,7 @@ class IndexSearchQuery extends SearchQuery {
     List<dynamic /* double | List<double> */ >? vector,
     bool? showRankingScoreDetails,
     double? rankingScoreThreshold,
+    bool? useNetwork,
   }) =>
       IndexSearchQuery(
         query: query ?? this.query,
@@ -103,5 +105,6 @@ class IndexSearchQuery extends SearchQuery {
             showRankingScoreDetails ?? this.showRankingScoreDetails,
         rankingScoreThreshold:
             rankingScoreThreshold ?? this.rankingScoreThreshold,
+        useNetwork: useNetwork ?? this.useNetwork,
       );
 }

--- a/lib/src/query_parameters/search_query.dart
+++ b/lib/src/query_parameters/search_query.dart
@@ -31,6 +31,7 @@ class SearchQuery extends Queryable {
   final double? rankingScoreThreshold;
   @RequiredMeiliServerVersion('1.3.0')
   final List<dynamic /* double | List<double> */ >? vector;
+  final bool? useNetwork;
 
   const SearchQuery({
     this.offset,
@@ -56,6 +57,7 @@ class SearchQuery extends Queryable {
     this.showRankingScoreDetails,
     this.rankingScoreThreshold,
     this.vector,
+    this.useNetwork,
   });
 
   @override
@@ -83,6 +85,7 @@ class SearchQuery extends Queryable {
       'showRankingScoreDetails': showRankingScoreDetails,
       'rankingScoreThreshold': rankingScoreThreshold,
       'vector': vector,
+      'useNetwork': useNetwork,
     };
   }
 
@@ -110,6 +113,7 @@ class SearchQuery extends Queryable {
     List<dynamic>? vector,
     bool? showRankingScoreDetails,
     double? rankingScoreThreshold,
+    bool? useNetwork,
   }) =>
       SearchQuery(
         offset: offset ?? this.offset,
@@ -138,5 +142,6 @@ class SearchQuery extends Queryable {
             showRankingScoreDetails ?? this.showRankingScoreDetails,
         rankingScoreThreshold:
             rankingScoreThreshold ?? this.rankingScoreThreshold,
+        useNetwork: useNetwork ?? this.useNetwork,
       );
 }

--- a/lib/src/query_parameters/search_query.dart
+++ b/lib/src/query_parameters/search_query.dart
@@ -31,6 +31,7 @@ class SearchQuery extends Queryable {
   final double? rankingScoreThreshold;
   @RequiredMeiliServerVersion('1.3.0')
   final List<dynamic /* double | List<double> */ >? vector;
+  @RequiredMeiliServerVersion('1.37.0')
   final bool? useNetwork;
 
   const SearchQuery({

--- a/lib/src/results/_exports.dart
+++ b/lib/src/results/_exports.dart
@@ -14,4 +14,5 @@ export 'all_stats.dart';
 export 'network.dart';
 export 'facet_stat.dart';
 export 'document_container.dart';
+export 'experimental_features.dart';
 export 'ranking_rules/_exports.dart';

--- a/lib/src/results/_exports.dart
+++ b/lib/src/results/_exports.dart
@@ -14,5 +14,4 @@ export 'all_stats.dart';
 export 'network.dart';
 export 'facet_stat.dart';
 export 'document_container.dart';
-export 'experimental_features.dart';
 export 'ranking_rules/_exports.dart';

--- a/lib/src/results/_exports.dart
+++ b/lib/src/results/_exports.dart
@@ -11,6 +11,7 @@ export 'match_position.dart';
 export 'matching_strategy_enum.dart';
 export 'index_stats.dart';
 export 'all_stats.dart';
+export 'network.dart';
 export 'facet_stat.dart';
 export 'document_container.dart';
 export 'ranking_rules/_exports.dart';

--- a/lib/src/results/experimental_features.dart
+++ b/lib/src/results/experimental_features.dart
@@ -11,7 +11,9 @@ part 'experimental_features.g.dart';
   createToJson: false,
 )
 class ExperimentalFeatures {
-  const ExperimentalFeatures();
+  const ExperimentalFeatures({this.network});
+
+  final bool? network;
 
   factory ExperimentalFeatures.fromJson(Map<String, dynamic> src) {
     return _$ExperimentalFeaturesFromJson(src);

--- a/lib/src/results/experimental_features.dart
+++ b/lib/src/results/experimental_features.dart
@@ -24,7 +24,9 @@ class ExperimentalFeatures {
   createFactory: false,
 )
 class UpdateExperimentalFeatures {
-  const UpdateExperimentalFeatures();
+  const UpdateExperimentalFeatures({this.network});
+
+  final bool? network;
 
   Map<String, dynamic> toJson() => _$UpdateExperimentalFeaturesToJson(this);
 }

--- a/lib/src/results/experimental_features.g.dart
+++ b/lib/src/results/experimental_features.g.dart
@@ -8,7 +8,9 @@ part of 'experimental_features.dart';
 
 ExperimentalFeatures _$ExperimentalFeaturesFromJson(
         Map<String, dynamic> json) =>
-    ExperimentalFeatures();
+    ExperimentalFeatures(
+      network: json['network'] as bool?,
+    );
 
 Map<String, dynamic> _$UpdateExperimentalFeaturesToJson(
         UpdateExperimentalFeatures instance) =>

--- a/lib/src/results/experimental_features.g.dart
+++ b/lib/src/results/experimental_features.g.dart
@@ -12,4 +12,6 @@ ExperimentalFeatures _$ExperimentalFeaturesFromJson(
 
 Map<String, dynamic> _$UpdateExperimentalFeaturesToJson(
         UpdateExperimentalFeatures instance) =>
-    <String, dynamic>{};
+    <String, dynamic>{
+      if (instance.network case final value?) 'network': value,
+    };

--- a/lib/src/results/network.dart
+++ b/lib/src/results/network.dart
@@ -27,7 +27,7 @@ Map<String, Object?>? _asObjectMap(Object? raw) {
 }
 
 /// Remote Meilisearch instance in a [Network] topology.
-@RequiredMeiliServerVersion('1.13.0')
+@RequiredMeiliServerVersion('1.37.0')
 class Remote {
   const Remote({
     this.url,
@@ -58,7 +58,7 @@ class Remote {
 }
 
 /// Shard ownership configuration within a [Network].
-@RequiredMeiliServerVersion('1.13.0')
+@RequiredMeiliServerVersion('1.37.0')
 class Shard {
   const Shard({
     this.remotes,
@@ -88,23 +88,19 @@ class Shard {
 }
 
 /// Network topology returned by `GET /network` / `PATCH /network`.
-@RequiredMeiliServerVersion('1.13.0')
+@RequiredMeiliServerVersion('1.37.0')
 class Network {
   const Network({
     this.self,
     this.leader,
     this.remotes,
     this.shards,
-    this.previousRemotes,
-    this.previousShards,
   });
 
   final String? self;
   final String? leader;
   final Map<String, Remote>? remotes;
   final Map<String, Shard>? shards;
-  final Map<String, Remote>? previousRemotes;
-  final Map<String, Shard>? previousShards;
 
   factory Network.fromMap(Map<String, Object?> json) {
     Map<String, Remote>? remotes;
@@ -129,35 +125,11 @@ class Network {
       );
     }
 
-    Map<String, Remote>? previousRemotes;
-    final prevRemotesRaw = _asObjectMap(json['previousRemotes']);
-    if (prevRemotesRaw != null) {
-      previousRemotes = prevRemotesRaw.map(
-        (k, v) => MapEntry(
-          k,
-          Remote.fromMap(Map<String, Object?>.from(v! as Map)),
-        ),
-      );
-    }
-
-    Map<String, Shard>? previousShards;
-    final prevShardsRaw = _asObjectMap(json['previousShards']);
-    if (prevShardsRaw != null) {
-      previousShards = prevShardsRaw.map(
-        (k, v) => MapEntry(
-          k,
-          Shard.fromMap(Map<String, Object?>.from(v! as Map)),
-        ),
-      );
-    }
-
     return Network(
       self: json['self'] as String?,
       leader: json['leader'] as String?,
       remotes: remotes,
       shards: shards,
-      previousRemotes: previousRemotes,
-      previousShards: previousShards,
     );
   }
 }
@@ -167,7 +139,7 @@ class Network {
 /// Omit a field to leave it unchanged. Pass [leader] or [self] as `null` to
 /// clear. For [remotes] / [shards], pass a map; use `null` values for entries
 /// to remove a remote or shard.
-@RequiredMeiliServerVersion('1.13.0')
+@RequiredMeiliServerVersion('1.37.0')
 class UpdateNetworkOptions {
   UpdateNetworkOptions({
     Object? self = _unset,

--- a/lib/src/results/network.dart
+++ b/lib/src/results/network.dart
@@ -1,0 +1,223 @@
+import '../annotations.dart';
+
+class _Unset {
+  const _Unset();
+}
+
+const Object _unset = _Unset();
+
+List<String>? _stringList(Object? raw) {
+  if (raw == null) {
+    return null;
+  }
+  if (raw is Iterable) {
+    return raw.map((e) => e.toString()).toList();
+  }
+  return null;
+}
+
+Map<String, Object?>? _asObjectMap(Object? raw) {
+  if (raw == null) {
+    return null;
+  }
+  if (raw is Map) {
+    return raw.map((k, v) => MapEntry(k.toString(), v));
+  }
+  return null;
+}
+
+/// Remote Meilisearch instance in a [Network] topology.
+@RequiredMeiliServerVersion('1.13.0')
+class Remote {
+  const Remote({
+    this.url,
+    this.searchApiKey,
+    this.writeApiKey,
+  });
+
+  final String? url;
+  final String? searchApiKey;
+  final String? writeApiKey;
+
+  factory Remote.fromMap(Map<String, Object?> map) {
+    return Remote(
+      url: map['url'] as String?,
+      searchApiKey: map['searchApiKey'] as String?,
+      writeApiKey: map['writeApiKey'] as String?,
+    );
+  }
+
+  /// Fields to send in a PATCH body (sparse).
+  Map<String, Object?> toPatchMap() {
+    return <String, Object?>{
+      if (url != null) 'url': url,
+      if (searchApiKey != null) 'searchApiKey': searchApiKey,
+      if (writeApiKey != null) 'writeApiKey': writeApiKey,
+    };
+  }
+}
+
+/// Shard ownership configuration within a [Network].
+@RequiredMeiliServerVersion('1.13.0')
+class Shard {
+  const Shard({
+    this.remotes,
+    this.addRemotes,
+    this.removeRemotes,
+  });
+
+  final List<String>? remotes;
+  final List<String>? addRemotes;
+  final List<String>? removeRemotes;
+
+  factory Shard.fromMap(Map<String, Object?> map) {
+    return Shard(
+      remotes: _stringList(map['remotes']),
+      addRemotes: _stringList(map['addRemotes']),
+      removeRemotes: _stringList(map['removeRemotes']),
+    );
+  }
+
+  Map<String, Object?> toPatchMap() {
+    return <String, Object?>{
+      if (remotes != null) 'remotes': remotes,
+      if (addRemotes != null) 'addRemotes': addRemotes,
+      if (removeRemotes != null) 'removeRemotes': removeRemotes,
+    };
+  }
+}
+
+/// Network topology returned by `GET /network` / `PATCH /network`.
+@RequiredMeiliServerVersion('1.13.0')
+class Network {
+  const Network({
+    this.self,
+    this.leader,
+    this.remotes,
+    this.shards,
+    this.previousRemotes,
+    this.previousShards,
+  });
+
+  final String? self;
+  final String? leader;
+  final Map<String, Remote>? remotes;
+  final Map<String, Shard>? shards;
+  final Map<String, Remote>? previousRemotes;
+  final Map<String, Shard>? previousShards;
+
+  factory Network.fromMap(Map<String, Object?> json) {
+    Map<String, Remote>? remotes;
+    final remotesRaw = _asObjectMap(json['remotes']);
+    if (remotesRaw != null) {
+      remotes = remotesRaw.map(
+        (k, v) => MapEntry(
+          k,
+          Remote.fromMap(Map<String, Object?>.from(v! as Map)),
+        ),
+      );
+    }
+
+    Map<String, Shard>? shards;
+    final shardsRaw = _asObjectMap(json['shards']);
+    if (shardsRaw != null) {
+      shards = shardsRaw.map(
+        (k, v) => MapEntry(
+          k,
+          Shard.fromMap(Map<String, Object?>.from(v! as Map)),
+        ),
+      );
+    }
+
+    Map<String, Remote>? previousRemotes;
+    final prevRemotesRaw = _asObjectMap(json['previousRemotes']);
+    if (prevRemotesRaw != null) {
+      previousRemotes = prevRemotesRaw.map(
+        (k, v) => MapEntry(
+          k,
+          Remote.fromMap(Map<String, Object?>.from(v! as Map)),
+        ),
+      );
+    }
+
+    Map<String, Shard>? previousShards;
+    final prevShardsRaw = _asObjectMap(json['previousShards']);
+    if (prevShardsRaw != null) {
+      previousShards = prevShardsRaw.map(
+        (k, v) => MapEntry(
+          k,
+          Shard.fromMap(Map<String, Object?>.from(v! as Map)),
+        ),
+      );
+    }
+
+    return Network(
+      self: json['self'] as String?,
+      leader: json['leader'] as String?,
+      remotes: remotes,
+      shards: shards,
+      previousRemotes: previousRemotes,
+      previousShards: previousShards,
+    );
+  }
+}
+
+/// Partial update payload for `PATCH /network`.
+///
+/// Omit a field to leave it unchanged. Pass [leader] or [self] as `null` to
+/// clear. For [remotes] / [shards], pass a map; use `null` values for entries
+/// to remove a remote or shard.
+@RequiredMeiliServerVersion('1.13.0')
+class UpdateNetworkOptions {
+  UpdateNetworkOptions({
+    Object? self = _unset,
+    Object? leader = _unset,
+    Object? remotes = _unset,
+    Object? shards = _unset,
+  })  : _self = self,
+        _leader = leader,
+        _remotes = remotes,
+        _shards = shards;
+
+  final Object? _self;
+  final Object? _leader;
+  final Object? _remotes;
+  final Object? _shards;
+
+  Map<String, Object?> toPatchMap() {
+    final out = <String, Object?>{};
+    if (!identical(_self, _unset)) {
+      out['self'] = _self as String?;
+    }
+    if (!identical(_leader, _unset)) {
+      out['leader'] = _leader as String?;
+    }
+    if (!identical(_remotes, _unset)) {
+      final m = _remotes as Map<String, Remote?>?;
+      if (m != null) {
+        out['remotes'] = m.map(
+          (k, v) => MapEntry(
+            k,
+            v?.toPatchMap(),
+          ),
+        );
+      } else {
+        out['remotes'] = null;
+      }
+    }
+    if (!identical(_shards, _unset)) {
+      final m = _shards as Map<String, Shard?>?;
+      if (m != null) {
+        out['shards'] = m.map(
+          (k, v) => MapEntry(
+            k,
+            v?.toPatchMap(),
+          ),
+        );
+      } else {
+        out['shards'] = null;
+      }
+    }
+    return out;
+  }
+}

--- a/test/experimental_features_test.dart
+++ b/test/experimental_features_test.dart
@@ -1,0 +1,36 @@
+import 'package:meilisearch/meilisearch.dart';
+import 'package:test/test.dart';
+
+import 'utils/client.dart';
+
+void main() {
+  group('Experimental Features', () {
+    setUpClient();
+
+    test('getExperimentalFeatures returns network flag', () async {
+      final features = await client.getExperimentalFeatures();
+      // We don't know the default, but it should be a boolean if it exists in the response
+      // For now, we just want to ensure we can access the field.
+      // This will fail to compile if the field is missing.
+      expect(features.network, isA<bool?>());
+    });
+
+    test('updateExperimentalFeatures updates network flag', () async {
+      // Toggle it to true
+      await client.updateExperimentalFeatures(
+        const UpdateExperimentalFeatures(network: true),
+      );
+
+      var features = await client.getExperimentalFeatures();
+      expect(features.network, isTrue);
+
+      // Toggle it back to false
+      await client.updateExperimentalFeatures(
+        const UpdateExperimentalFeatures(network: false),
+      );
+
+      features = await client.getExperimentalFeatures();
+      expect(features.network, isFalse);
+    });
+  });
+}

--- a/test/experimental_features_test.dart
+++ b/test/experimental_features_test.dart
@@ -1,4 +1,4 @@
-import 'package:meilisearch/meilisearch.dart';
+import 'package:meilisearch/src/results/experimental_features.dart';
 import 'package:test/test.dart';
 
 import 'utils/client.dart';
@@ -8,7 +8,7 @@ void main() {
     setUpClient();
 
     test('getExperimentalFeatures returns network flag', () async {
-      final features = await client.getExperimentalFeatures();
+      final features = await client.http.getExperimentalFeatures();
       // We don't know the default, but it should be a boolean if it exists in the response
       // For now, we just want to ensure we can access the field.
       // This will fail to compile if the field is missing.
@@ -17,19 +17,19 @@ void main() {
 
     test('updateExperimentalFeatures updates network flag', () async {
       // Toggle it to true
-      await client.updateExperimentalFeatures(
+      await client.http.updateExperimentalFeatures(
         const UpdateExperimentalFeatures(network: true),
       );
 
-      var features = await client.getExperimentalFeatures();
+      var features = await client.http.getExperimentalFeatures();
       expect(features.network, isTrue);
 
       // Toggle it back to false
-      await client.updateExperimentalFeatures(
+      await client.http.updateExperimentalFeatures(
         const UpdateExperimentalFeatures(network: false),
       );
 
-      features = await client.getExperimentalFeatures();
+      features = await client.http.getExperimentalFeatures();
       expect(features.network, isFalse);
     });
   });

--- a/test/network_api_test.dart
+++ b/test/network_api_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('Network models', () {
-    test('Network.fromMap parses self, leader, remotes, shards, previous*', () {
+    test('Network.fromMap parses self, leader, remotes, shards', () {
       final json = <String, Object?>{
         'self': 'ms-0',
         'leader': 'ms-0',
@@ -18,14 +18,6 @@ void main() {
         'shards': <String, Object?>{
           'shard-a': <String, Object?>{
             'remotes': <Object?>['ms-0', 'ms-1'],
-          },
-        },
-        'previousRemotes': <String, Object?>{
-          'old': <String, Object?>{'url': 'http://old'},
-        },
-        'previousShards': <String, Object?>{
-          'shard-p': <String, Object?>{
-            'remotes': <Object?>['ms-0'],
           },
         },
       };
@@ -43,11 +35,6 @@ void main() {
       expect(n.shards!['shard-a']!.remotes, ['ms-0', 'ms-1']);
       expect(n.shards!['shard-a']!.addRemotes, isNull);
       expect(n.shards!['shard-a']!.removeRemotes, isNull);
-
-      expect(n.previousRemotes, isNotNull);
-      expect(n.previousRemotes!['old']!.url, 'http://old');
-      expect(n.previousShards, isNotNull);
-      expect(n.previousShards!['shard-p']!.remotes, ['ms-0']);
     });
 
     test('Remote.toPatchMap is sparse', () {

--- a/test/network_api_test.dart
+++ b/test/network_api_test.dart
@@ -1,0 +1,313 @@
+import 'package:dio/dio.dart';
+import 'package:meilisearch/meilisearch.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Network models', () {
+    test('Network.fromMap parses self, leader, remotes, shards, previous*', () {
+      final json = <String, Object?>{
+        'self': 'ms-0',
+        'leader': 'ms-0',
+        'remotes': <String, Object?>{
+          'ms-1': <String, Object?>{
+            'url': 'http://localhost:7701',
+            'searchApiKey': 'sk',
+            'writeApiKey': 'wk',
+          },
+        },
+        'shards': <String, Object?>{
+          'shard-a': <String, Object?>{
+            'remotes': <Object?>['ms-0', 'ms-1'],
+          },
+        },
+        'previousRemotes': <String, Object?>{
+          'old': <String, Object?>{'url': 'http://old'},
+        },
+        'previousShards': <String, Object?>{
+          'shard-p': <String, Object?>{
+            'remotes': <Object?>['ms-0'],
+          },
+        },
+      };
+
+      final n = Network.fromMap(json);
+
+      expect(n.self, 'ms-0');
+      expect(n.leader, 'ms-0');
+      expect(n.remotes, isNotNull);
+      expect(n.remotes!['ms-1']!.url, 'http://localhost:7701');
+      expect(n.remotes!['ms-1']!.searchApiKey, 'sk');
+      expect(n.remotes!['ms-1']!.writeApiKey, 'wk');
+
+      expect(n.shards, isNotNull);
+      expect(n.shards!['shard-a']!.remotes, ['ms-0', 'ms-1']);
+      expect(n.shards!['shard-a']!.addRemotes, isNull);
+      expect(n.shards!['shard-a']!.removeRemotes, isNull);
+
+      expect(n.previousRemotes, isNotNull);
+      expect(n.previousRemotes!['old']!.url, 'http://old');
+      expect(n.previousShards, isNotNull);
+      expect(n.previousShards!['shard-p']!.remotes, ['ms-0']);
+    });
+
+    test('Remote.toPatchMap is sparse', () {
+      expect(
+        const Remote(url: 'http://a').toPatchMap(),
+        {'url': 'http://a'},
+      );
+      expect(
+        Remote(
+          url: 'http://a',
+          searchApiKey: 's',
+          writeApiKey: 'w',
+        ).toPatchMap(),
+        {
+          'url': 'http://a',
+          'searchApiKey': 's',
+          'writeApiKey': 'w',
+        },
+      );
+    });
+
+    test('Shard.toPatchMap is sparse', () {
+      expect(
+        const Shard(addRemotes: ['a']).toPatchMap(),
+        {
+          'addRemotes': ['a']
+        },
+      );
+      expect(
+        const Shard(remotes: ['x'], removeRemotes: ['y']).toPatchMap(),
+        {
+          'remotes': ['x'],
+          'removeRemotes': ['y'],
+        },
+      );
+    });
+
+    test('UpdateNetworkOptions builds partial PATCH bodies', () {
+      expect(UpdateNetworkOptions().toPatchMap(), isEmpty);
+
+      expect(
+        UpdateNetworkOptions(self: 'node-1').toPatchMap(),
+        {'self': 'node-1'},
+      );
+
+      expect(
+        UpdateNetworkOptions(leader: null).toPatchMap(),
+        {'leader': null},
+      );
+
+      expect(
+        UpdateNetworkOptions(
+          remotes: {
+            'r1': const Remote(url: 'http://one'),
+            'r2': null,
+          },
+        ).toPatchMap(),
+        {
+          'remotes': <String, Object?>{
+            'r1': {'url': 'http://one'},
+            'r2': null,
+          },
+        },
+      );
+
+      expect(
+        UpdateNetworkOptions(
+          shards: {
+            's1': const Shard(addRemotes: ['a']),
+          },
+        ).toPatchMap(),
+        {
+          'shards': <String, Object?>{
+            's1': {
+              'addRemotes': ['a']
+            },
+          },
+        },
+      );
+    });
+  });
+
+  group('MeiliSearchClient network', () {
+    test('getNetwork uses GET /network', () async {
+      final captured = <RequestOptions>[];
+      final client = MeiliSearchClient.withCustomDio(
+        'http://unit.test',
+        apiKey: 'masterKey',
+        interceptors: [
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              captured.add(options);
+              handler.resolve(
+                Response<Map<String, Object?>>(
+                  requestOptions: options,
+                  statusCode: 200,
+                  data: <String, Object?>{
+                    'self': 'ms-0',
+                    'remotes': <String, Object?>{},
+                  },
+                ),
+              );
+            },
+          ),
+        ],
+      );
+
+      final net = await client.getNetwork();
+
+      expect(captured, hasLength(1));
+      expect(captured.single.path, '/network');
+      expect(captured.single.method, 'GET');
+      expect(net.self, 'ms-0');
+      expect(net.remotes, isNotNull);
+      expect(net.remotes, isEmpty);
+    });
+
+    test('updateNetwork uses PATCH /network with body', () async {
+      RequestOptions? last;
+      final client = MeiliSearchClient.withCustomDio(
+        'http://unit.test',
+        apiKey: 'masterKey',
+        interceptors: [
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              last = options;
+              handler.resolve(
+                Response<Map<String, Object?>>(
+                  requestOptions: options,
+                  statusCode: 200,
+                  data: <String, Object?>{
+                    'self': 'x',
+                    'remotes': <String, Object?>{},
+                  },
+                ),
+              );
+            },
+          ),
+        ],
+      );
+
+      await client.updateNetwork(UpdateNetworkOptions(self: 'x'));
+
+      expect(last, isNotNull);
+      expect(last!.path, '/network');
+      expect(last!.method, 'PATCH');
+      expect(last!.data, {'self': 'x'});
+    });
+
+    test('addRemote builds remotes patch entry', () async {
+      Map<String, Object?>? data;
+      final client = MeiliSearchClient.withCustomDio(
+        'http://unit.test',
+        apiKey: 'masterKey',
+        interceptors: [
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              data = options.data as Map<String, Object?>?;
+              handler.resolve(
+                Response<Map<String, Object?>>(
+                  requestOptions: options,
+                  statusCode: 200,
+                  data: <String, Object?>{'remotes': <String, Object?>{}},
+                ),
+              );
+            },
+          ),
+        ],
+      );
+
+      await client.addRemote(
+        'peer',
+        const Remote(url: 'http://peer:7700', searchApiKey: 'sk'),
+      );
+
+      expect(data, {
+        'remotes': {
+          'peer': {'url': 'http://peer:7700', 'searchApiKey': 'sk'},
+        },
+      });
+    });
+
+    test('removeRemote nulls remote entry', () async {
+      Map<String, Object?>? data;
+      final client = MeiliSearchClient.withCustomDio(
+        'http://unit.test',
+        apiKey: 'masterKey',
+        interceptors: [
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              data = options.data as Map<String, Object?>?;
+              handler.resolve(
+                Response<Map<String, Object?>>(
+                  requestOptions: options,
+                  statusCode: 200,
+                  data: <String, Object?>{'remotes': <String, Object?>{}},
+                ),
+              );
+            },
+          ),
+        ],
+      );
+
+      await client.removeRemote('peer');
+
+      expect(data, {
+        'remotes': {'peer': null},
+      });
+    });
+
+    test('addRemotesToShard and removeRemotesFromShard', () async {
+      final bodies = <Map<String, Object?>?>[];
+      final client = MeiliSearchClient.withCustomDio(
+        'http://unit.test',
+        apiKey: 'masterKey',
+        interceptors: [
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              bodies.add(options.data as Map<String, Object?>?);
+              handler.resolve(
+                Response<Map<String, Object?>>(
+                  requestOptions: options,
+                  statusCode: 200,
+                  data: <String, Object?>{'shards': <String, Object?>{}},
+                ),
+              );
+            },
+          ),
+        ],
+      );
+
+      await client.addRemotesToShard('shard-1', ['a', 'b']);
+      await client.removeRemotesFromShard('shard-1', ['a']);
+
+      expect(bodies[0], {
+        'shards': {
+          'shard-1': {
+            'addRemotes': ['a', 'b']
+          },
+        },
+      });
+      expect(bodies[1], {
+        'shards': {
+          'shard-1': {
+            'removeRemotes': ['a']
+          },
+        },
+      });
+    });
+
+    test('updateNetwork rejects empty patch', () async {
+      final client = MeiliSearchClient.withCustomDio(
+        'http://unit.test',
+        apiKey: 'masterKey',
+      );
+
+      expect(
+        () => client.updateNetwork(UpdateNetworkOptions()),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/network_serialization_test.dart
+++ b/test/network_serialization_test.dart
@@ -1,0 +1,145 @@
+import 'package:dio/dio.dart';
+import 'package:meilisearch/meilisearch.dart';
+import 'package:meilisearch/src/results/experimental_features.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('network / useNetwork serialization', () {
+    test('UpdateExperimentalFeatures(network: true) serializes network', () {
+      expect(
+        UpdateExperimentalFeatures(network: true).toJson(),
+        {'network': true},
+      );
+    });
+
+    test('SearchQuery(useNetwork: true) includes useNetwork in toSparseMap',
+        () {
+      expect(
+        SearchQuery(useNetwork: true).toSparseMap(),
+        containsPair('useNetwork', true),
+      );
+    });
+
+    test(
+      'IndexSearchQuery(indexUid, useNetwork: true) includes useNetwork in toSparseMap',
+      () {
+        expect(
+          IndexSearchQuery(
+            indexUid: 'movies',
+            useNetwork: true,
+          ).toSparseMap(),
+          containsPair('useNetwork', true),
+        );
+      },
+    );
+
+    test(
+      'index.search sends useNetwork in POST body with SearchQuery',
+      () async {
+        Map<String, Object?>? body;
+        final client = MeiliSearchClient.withCustomDio(
+          'http://unit.test',
+          apiKey: 'masterKey',
+          interceptors: [
+            InterceptorsWrapper(
+              onRequest: (options, handler) {
+                body = options.data as Map<String, Object?>?;
+                handler.resolve(
+                  Response<Map<String, Object?>>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: <String, Object?>{
+                      'hits': <Object?>[],
+                      'processingTimeMs': 0,
+                    },
+                  ),
+                );
+              },
+            ),
+          ],
+        );
+
+        await client.index('movies').search(
+              'hello',
+              const SearchQuery(useNetwork: true),
+            );
+
+        expect(body, isNotNull);
+        expect(body!['q'], 'hello');
+        expect(body!['useNetwork'], true);
+      },
+    );
+
+    test(
+      'multiSearch sends useNetwork inside each queries[] entry',
+      () async {
+        Map<String, Object?>? body;
+        final client = MeiliSearchClient.withCustomDio(
+          'http://unit.test',
+          apiKey: 'masterKey',
+          interceptors: [
+            InterceptorsWrapper(
+              onRequest: (options, handler) {
+                body = options.data as Map<String, Object?>?;
+                handler.resolve(
+                  Response<Map<String, Object?>>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: <String, Object?>{
+                      'results': <Object?>[
+                        <String, Object?>{
+                          'indexUid': 'movies',
+                          'hits': <Object?>[],
+                          'processingTimeMs': 0,
+                        },
+                      ],
+                    },
+                  ),
+                );
+              },
+            ),
+          ],
+        );
+
+        await client.multiSearch(
+          MultiSearchQuery(
+            queries: [
+              const IndexSearchQuery(
+                indexUid: 'movies',
+                query: 'nemo',
+                useNetwork: true,
+              ),
+            ],
+          ),
+        );
+
+        expect(body, isNotNull);
+        final queries = body!['queries'] as List<Object?>?;
+        expect(queries, hasLength(1));
+        final first = queries!.single as Map<String, Object?>;
+        expect(first['indexUid'], 'movies');
+        expect(first['q'], 'nemo');
+        expect(first['useNetwork'], true);
+      },
+    );
+
+    test('MultiSearchQuery propagates useNetwork via queries sparse maps', () {
+      final sparse = MultiSearchQuery(
+        queries: [
+          const IndexSearchQuery(
+            indexUid: 'movies',
+            query: 'x',
+            useNetwork: true,
+          ),
+        ],
+      ).toSparseMap();
+
+      final queries = sparse['queries'] as List<Object?>?;
+      expect(queries, hasLength(1));
+      expect(
+        queries!.single as Map<String, Object?>,
+        containsPair('useNetwork', true),
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #443, fixes #458, and actually brings compatibility to [Meilisearch v1.37](https://github.com/meilisearch/meilisearch/releases/tag/v1.37.0)

## What does this PR do?
- Add `getNetwork`, `updateNetwork`, `add/removeRemote`, `add/removeRemotesToShard` methods to manage network topology
- Add optional `useNetwork` to `SearchQuery` / `IndexSearchQuery` models  
- Add a `network` field to `UpdateExperimentalFeatures` 

## AI disclosure
Cursor with `gpt-5.4-medium` and `codex-5.3-medium`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network topology management API with methods to query network configuration, add/remove remotes, and manage shard assignments (requires Meilisearch 1.37.0+).
  * Added `useNetwork` option to search queries for network-aware search capabilities.
  * Added experimental network feature toggle.

* **Tests**
  * Added comprehensive test coverage for network topology API and query serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->