### PR TITLE
Remove unused code samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -140,7 +140,6 @@ get_version_1: |-
   await client.getVersion();
 distinct_attribute_guide_1: |-
   await client.index('jackets').updateDistinctAttribute('product_id');
-field_properties_guide_searchable_1: "await client\n    .index('movies')\n    .updateSearchableAttributes(['title', 'overview', 'genres']);"
 field_properties_guide_displayed_1: "await client.index('movies').updateDisplayedAttributes([\n  'title',\n  'overview',\n  'genres',\n  'release_date',\n]);"
 filtering_guide_1: "await client.index('movie_ratings').search(\n      'Avengers',\n      SearchQuery(\n        filterExpression: Meili.gt(\n          Meili.attr('release_date'),\n          DateTime.utc(1995, 3, 18).toMeiliValue(),\n        ),\n      ),\n    );"
 filtering_guide_2: "await client.index('movie_ratings').search(\n      'Batman',\n      SearchQuery(\n        filterExpression: Meili.and([\n          Meili.attr('release_date')\n              .gt(DateTime.utc(1995, 3, 18).toMeiliValue()),\n          Meili.or([\n            'director'.toMeiliAttribute().eq('Tim Burton'.toMeiliValue()),\n            'director'\n                .toMeiliAttribute()\n                .eq('Christopher Nolan'.toMeiliValue()),\n          ]),\n        ]),\n      ),\n    );"

--- a/test/code_samples.dart
+++ b/test/code_samples.dart
@@ -413,12 +413,6 @@ void main() {
       await client.index('jackets').updateDistinctAttribute('product_id');
       // #enddocregion
 
-      // #docregion field_properties_guide_searchable_1
-      await client
-          .index('movies')
-          .updateSearchableAttributes(['title', 'overview', 'genres']);
-      // #enddocregion
-
       // #docregion field_properties_guide_displayed_1
       await client.index('movies').updateDisplayedAttributes([
         'title',


### PR DESCRIPTION
Removes unused code samples from `.code-samples.meilisearch.yaml` that are neither referenced in the docs nor in the local config:
- `field_properties_guide_searchable_1`

Flagged by the CI: https://github.com/meilisearch/documentation/actions/runs/24176332506/job/70558505454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed a documentation code sample that showed updating an index's searchable attributes; the sample has been removed from the guide.
  * All other guide examples (displayed fields, filtering, sorting) remain unchanged.
  * This update only affects example content in the docs and does not change runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->