### PR TITLE
Fix flaky export test when task uid is 0

### DIFF
--- a/test/export_test.dart
+++ b/test/export_test.dart
@@ -18,7 +18,7 @@ void main() {
         await result.waitFor(client: client, throwFailed: false);
       });
 
-      expect(result.uid, greaterThan(0));
+      expect(result.uid, greaterThanOrEqualTo(0));
       expect(result.indexUid, isNull);
       expect(result.status, equals("enqueued"));
       expect(result.type, equals("export"));


### PR DESCRIPTION
## Why

The `Export enqueues a task without external network` test fails intermittently even without any merge:

```
❌ test/export_test.dart: Export Export enqueues a task without external network (failed)
  Expected: a value greater than <0>
    Actual: <0>
```

The test asserted `result.uid` was `greaterThan(0)`, but the **first task created on a fresh Meilisearch instance has `uid` 0**. Depending on test execution order and the task-queue state, the export task can legitimately be assigned `uid 0`, which makes the assertion fail. This is an environment/ordering flake, not a code regression.

## What

Accept `0` as a valid task uid: `greaterThan(0)` → `greaterThanOrEqualTo(0)`. The assertion still verifies a non-null uid was returned and a task was enqueued; the `status`/`type`/`indexUid` checks are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an export test to accept task IDs starting at `0` as well as higher values.
  * No user-facing behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->